### PR TITLE
[BE] issue99: 태그ID로 필터링하여 스터디 검색하도록 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/moamoa/study/controller/request/TagRequest.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/controller/request/TagRequest.java
@@ -10,26 +10,26 @@ import lombok.ToString;
 @ToString
 public class TagRequest {
 
-    private final List<String> generation;
-    private final List<String> area;
-    private final List<String> tag;
+    private final List<Long> generation;
+    private final List<Long> area;
+    private final List<Long> tag;
 
-    public TagRequest(final List<String> generation, final List<String> area, final List<String> tag) {
+    public TagRequest(final List<Long> generation, final List<Long> area, final List<Long> tag) {
         this.generation = Objects.requireNonNullElseGet(generation, ArrayList::new);
         this.area = Objects.requireNonNullElseGet(area, ArrayList::new);
         this.tag = Objects.requireNonNullElseGet(tag, ArrayList::new);
     }
 
-    public List<String> getFilterNames() {
-        List<String> filterNames = new ArrayList<>();
-        filterNames.addAll(generation);
-        filterNames.addAll(area);
-        filterNames.addAll(tag);
+    public List<Long> getFilterIds() {
+        List<Long> filterIds = new ArrayList<>();
+        filterIds.addAll(generation);
+        filterIds.addAll(area);
+        filterIds.addAll(tag);
 
-        return filterNames;
+        return filterIds;
     }
 
     public boolean isEmpty() {
-        return getFilterNames().isEmpty();
+        return getFilterIds().isEmpty();
     }
 }

--- a/backend/src/main/java/com/woowacourse/moamoa/study/service/StudyTagService.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/service/StudyTagService.java
@@ -54,11 +54,11 @@ public class StudyTagService {
     }
 
     private List<Tag> getFilterFromName(final TagRequest tagRequest) {
-        final List<String> filterNames = tagRequest.getFilterNames();
+        final List<Long> filterIds = tagRequest.getFilterIds();
         final List<Tag> tags = new ArrayList<>();
 
-        for (String filterName : filterNames) {
-            final Tag tag = tagRepository.findByName(filterName)
+        for (Long filterId : filterIds) {
+            final Tag tag = tagRepository.findById(filterId)
                     .orElseThrow(TagNotExistException::new);
             tags.add(tag);
         }

--- a/backend/src/main/java/com/woowacourse/moamoa/tag/domain/repository/JpaTagRepository.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/tag/domain/repository/JpaTagRepository.java
@@ -1,9 +1,7 @@
 package com.woowacourse.moamoa.tag.domain.repository;
 
 import com.woowacourse.moamoa.tag.domain.Tag;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaTagRepository extends JpaRepository<Tag, Long>, TagRepository {
-    Optional<Tag> findByName(String name);
 }

--- a/backend/src/main/java/com/woowacourse/moamoa/tag/domain/repository/TagRepository.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/tag/domain/repository/TagRepository.java
@@ -7,5 +7,6 @@ import java.util.Optional;
 public interface TagRepository {
 
     List<Tag> findAllByNameContainingIgnoreCase(String name);
-    Optional<Tag> findByName(String name);
+
+    Optional<Tag> findById(Long id);
 }

--- a/backend/src/test/java/com/woowacourse/acceptance/study/SearchingStudiesAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/acceptance/study/SearchingStudiesAcceptanceTest.java
@@ -126,7 +126,7 @@ public class SearchingStudiesAcceptanceTest extends AcceptanceTest {
     public void getStudiesByFilter() {
         RestAssured.given().log().all()
                 .queryParam("title", "")
-                .queryParam("area", "BE")
+                .queryParam("area", 3)
                 .queryParam("page", 0)
                 .queryParam("size", 3)
                 .when().log().all()
@@ -147,7 +147,7 @@ public class SearchingStudiesAcceptanceTest extends AcceptanceTest {
     public void getStudiesByFilterAndTitle() {
         RestAssured.given().log().all()
                 .queryParam("title", "ja")
-                .queryParam("area", "BE")
+                .queryParam("area", 3)
                 .queryParam("page", 0)
                 .queryParam("size", 3)
                 .when().log().all()
@@ -168,8 +168,8 @@ public class SearchingStudiesAcceptanceTest extends AcceptanceTest {
     public void getStudiesBySameCategoryFilter() {
         RestAssured.given().log().all()
                 .queryParam("title", "")
-                .queryParam("area", "BE")
-                .queryParam("area", "FE")
+                .queryParam("area", 3)
+                .queryParam("area", 4)
                 .queryParam("page", 0)
                 .queryParam("size", 5)
                 .when().log().all()
@@ -195,8 +195,8 @@ public class SearchingStudiesAcceptanceTest extends AcceptanceTest {
     public void getStudiesByAnotherCategoryFilter() {
         RestAssured.given().log().all()
                 .queryParam("title", "")
-                .queryParam("area", "BE")
-                .queryParam("tag", "Java")
+                .queryParam("area", 3)
+                .queryParam("tag", 1)
                 .queryParam("page", 0)
                 .queryParam("size", 3)
                 .when().log().all()

--- a/backend/src/test/java/com/woowacourse/moamoa/study/domain/studytag/repository/CustomStudyTagRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/study/domain/studytag/repository/CustomStudyTagRepositoryTest.java
@@ -131,9 +131,9 @@ class CustomStudyTagRepositoryTest {
     @Test
     public void searchByFilters() {
         // given
-        Tag tag_4기 = tagRepository.findByName("4기").orElseThrow();
-        Tag tag_BE = tagRepository.findByName("BE").orElseThrow();
-        Tag tag_FE = tagRepository.findByName("FE").orElseThrow();
+        Tag tag_4기 = tagRepository.findById(2L).orElseThrow();
+        Tag tag_BE = tagRepository.findById(3L).orElseThrow();
+        Tag tag_FE = tagRepository.findById(4L).orElseThrow();
 
         final PageRequest pageRequest = PageRequest.of(0, 5);
         final StudySearchCondition searchCondition = new StudySearchCondition("",
@@ -163,9 +163,9 @@ class CustomStudyTagRepositoryTest {
     @Test
     public void searchByFiltersWithTitle() {
         // given
-        Tag tag_4기 = tagRepository.findByName("4기").orElseThrow();
-        Tag tag_BE = tagRepository.findByName("BE").orElseThrow();
-        Tag tag_FE = tagRepository.findByName("FE").orElseThrow();
+        Tag tag_4기 = tagRepository.findById(2L).orElseThrow();
+        Tag tag_BE = tagRepository.findById(3L).orElseThrow();
+        Tag tag_FE = tagRepository.findById(4L).orElseThrow();
 
         final PageRequest pageRequest = PageRequest.of(0, 5);
         final StudySearchCondition searchCondition = new StudySearchCondition("java",


### PR DESCRIPTION
## 요약

태그 ID로 필터링하여 스터디 검색하도록 수정

## 세부사항

기존 태그 이름(name)을 받아서 필터링 하던 것에서 태그 ID를 받아 필터링하여 스터디를 검색하도록 수정

close #99 
