### PR TITLE
[BE] issue50: 로그인 기능 리팩터링

### DIFF
--- a/backend/src/main/java/com/woowacourse/moamoa/auth/config/AuthConfig.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/config/AuthConfig.java
@@ -11,12 +11,12 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class AuthConfiguration implements WebMvcConfigurer {
+public class AuthConfig implements WebMvcConfigurer {
 
     private final AuthenticationInterceptor authenticationInterceptor;
     private final AuthenticationArgumentResolver authenticationArgumentResolver;
 
-    public AuthConfiguration(
+    public AuthConfig(
             final AuthenticationInterceptor authenticationInterceptor,
             final AuthenticationArgumentResolver authenticationArgumentResolver) {
         this.authenticationInterceptor = authenticationInterceptor;

--- a/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthenticationArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthenticationArgumentResolver.java
@@ -4,7 +4,7 @@ import com.woowacourse.moamoa.auth.config.AuthenticationExtractor;
 import com.woowacourse.moamoa.auth.config.AuthenticationPrincipal;
 import com.woowacourse.moamoa.auth.infrastructure.TokenProvider;
 import javax.servlet.http.HttpServletRequest;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -13,10 +13,10 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
+@RequiredArgsConstructor
 public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
 
-    @Autowired
-    private TokenProvider tokenProvider;
+    private final TokenProvider tokenProvider;
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {

--- a/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthenticationArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthenticationArgumentResolver.java
@@ -2,7 +2,7 @@ package com.woowacourse.moamoa.auth.controller;
 
 import com.woowacourse.moamoa.auth.config.AuthenticationExtractor;
 import com.woowacourse.moamoa.auth.config.AuthenticationPrincipal;
-import com.woowacourse.moamoa.auth.infrastructure.JwtTokenProvider;
+import com.woowacourse.moamoa.auth.infrastructure.TokenProvider;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.MethodParameter;
@@ -16,7 +16,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Autowired
-    private JwtTokenProvider jwtTokenProvider;
+    private TokenProvider tokenProvider;
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
@@ -29,6 +29,6 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
         final HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
 
         final String token = AuthenticationExtractor.extract(request);
-        return Long.valueOf(jwtTokenProvider.getPayload(token));
+        return Long.valueOf(tokenProvider.getPayload(token));
     }
 }

--- a/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthenticationArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthenticationArgumentResolver.java
@@ -3,6 +3,7 @@ package com.woowacourse.moamoa.auth.controller;
 import com.woowacourse.moamoa.auth.config.AuthenticationExtractor;
 import com.woowacourse.moamoa.auth.config.AuthenticationPrincipal;
 import com.woowacourse.moamoa.auth.infrastructure.TokenProvider;
+import com.woowacourse.moamoa.common.exception.UnauthorizedException;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -29,6 +30,10 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
         final HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
 
         final String token = AuthenticationExtractor.extract(request);
+        if (token == null) {
+            throw new UnauthorizedException("인증 타입이 올바르지 않습니다.");
+        }
+
         return Long.valueOf(tokenProvider.getPayload(token));
     }
 }

--- a/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthenticationInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthenticationInterceptor.java
@@ -1,7 +1,7 @@
 package com.woowacourse.moamoa.auth.controller;
 
 import com.woowacourse.moamoa.auth.config.AuthenticationExtractor;
-import com.woowacourse.moamoa.auth.infrastructure.JwtTokenProvider;
+import com.woowacourse.moamoa.auth.infrastructure.TokenProvider;
 import com.woowacourse.moamoa.common.exception.UnauthorizedException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -14,7 +14,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @RequiredArgsConstructor
 public class AuthenticationInterceptor implements HandlerInterceptor {
 
-    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenProvider tokenProvider;
 
     @Override
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) {
@@ -26,7 +26,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
             String token = AuthenticationExtractor.extract(request);
             validateToken(token);
 
-            request.setAttribute("payload", jwtTokenProvider.getPayload(token));
+            request.setAttribute("payload", tokenProvider.getPayload(token));
         }
 
         return true;
@@ -37,7 +37,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     }
 
     private void validateToken(String token) {
-        if (token == null || !jwtTokenProvider.validateToken(token)) {
+        if (token == null || !tokenProvider.validateToken(token)) {
             throw new UnauthorizedException("유효하지 않은 토큰입니다.");
         }
     }

--- a/backend/src/main/java/com/woowacourse/moamoa/auth/infrastructure/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/infrastructure/JwtTokenProvider.java
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-public class JwtTokenProvider {
+public class JwtTokenProvider implements TokenProvider {
 
     private final SecretKey key;
     private final long validityInMilliseconds;
@@ -26,6 +26,7 @@ public class JwtTokenProvider {
         this.validityInMilliseconds = validityInMilliseconds;
     }
 
+    @Override
     public String createToken(final Long payload) {
         final Date now = new Date();
         final Date validity = new Date(now.getTime() + validityInMilliseconds);
@@ -38,6 +39,7 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    @Override
     public String getPayload(final String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(key)
@@ -47,6 +49,7 @@ public class JwtTokenProvider {
                 .getSubject();
     }
 
+    @Override
     public boolean validateToken(final String token) {
         try {
             Jws<Claims> claims = Jwts.parserBuilder()

--- a/backend/src/main/java/com/woowacourse/moamoa/auth/infrastructure/TokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/infrastructure/TokenProvider.java
@@ -1,0 +1,10 @@
+package com.woowacourse.moamoa.auth.infrastructure;
+
+public interface TokenProvider {
+
+    String createToken(final Long payload);
+
+    String getPayload(final String token);
+
+    boolean validateToken(final String token);
+}

--- a/backend/src/main/java/com/woowacourse/moamoa/auth/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/service/AuthService.java
@@ -1,6 +1,6 @@
 package com.woowacourse.moamoa.auth.service;
 
-import com.woowacourse.moamoa.auth.infrastructure.JwtTokenProvider;
+import com.woowacourse.moamoa.auth.infrastructure.TokenProvider;
 import com.woowacourse.moamoa.auth.service.oauthclient.OAuthClient;
 import com.woowacourse.moamoa.auth.service.oauthclient.response.GithubProfileResponse;
 import com.woowacourse.moamoa.auth.service.response.TokenResponse;
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final MemberService memberService;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenProvider tokenProvider;
     private final OAuthClient oAuthClient;
 
     @Transactional
@@ -25,7 +25,7 @@ public class AuthService {
 
         memberService.saveOrUpdate(githubProfileResponse.toMember());
 
-        final String jwtToken = jwtTokenProvider.createToken(githubProfileResponse.getGitgubId());
+        final String jwtToken = tokenProvider.createToken(githubProfileResponse.getGitgubId());
         return new TokenResponse(jwtToken);
     }
 }

--- a/backend/src/test/java/com/woowacourse/moamoa/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/auth/controller/AuthControllerTest.java
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.woowacourse.moamoa.auth.infrastructure.JwtTokenProvider;
+import com.woowacourse.moamoa.auth.infrastructure.TokenProvider;
 import com.woowacourse.moamoa.auth.service.AuthService;
 import com.woowacourse.moamoa.auth.service.response.TokenResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +26,7 @@ public class AuthControllerTest {
     private AuthService authService;
 
     @MockBean
-    private JwtTokenProvider jwtTokenProvider;
+    private TokenProvider tokenProvider;
 
     @DisplayName("Authorization 요청과 응답 형식을 확인한다.")
     @Test

--- a/backend/src/test/java/com/woowacourse/moamoa/auth/controller/AuthenticationArgumentResolverTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/auth/controller/AuthenticationArgumentResolverTest.java
@@ -1,0 +1,66 @@
+package com.woowacourse.moamoa.auth.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.woowacourse.moamoa.auth.infrastructure.TokenProvider;
+import com.woowacourse.moamoa.common.exception.UnauthorizedException;
+import java.util.Collections;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.context.request.NativeWebRequest;
+
+@SpringBootTest
+class AuthenticationArgumentResolverTest {
+
+    @MockBean
+    private NativeWebRequest nativeWebRequest;
+
+    @MockBean
+    private HttpServletRequest httpServletRequest;
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @Autowired
+    private AuthenticationArgumentResolver authenticationArgumentResolver;
+
+    @DisplayName("Authorization 인증 타입이 Bearer이 아닌 경우 예외가 발생한다.")
+    @Test
+    void validAuthorizationTypeIsBearer() {
+        String wrongBearerToken = "Basic " + tokenProvider.createToken(1L);
+
+        given(nativeWebRequest.getNativeRequest(HttpServletRequest.class))
+                .willReturn(httpServletRequest);
+
+        given(httpServletRequest.getHeaders(HttpHeaders.AUTHORIZATION))
+                .willReturn(Collections.enumeration(List.of(wrongBearerToken)));
+
+        assertThatThrownBy(
+                () -> authenticationArgumentResolver.resolveArgument(null, null, nativeWebRequest, null))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessageContaining("인증 타입이 올바르지 않습니다.");
+    }
+
+    @DisplayName("Authorization 인증 타입이 Bearer인 경우 payload를 반환한다.")
+    @Test
+    void getToken() {
+        String wrongBearerToken = "Bearer " + tokenProvider.createToken(1L);
+
+        given(nativeWebRequest.getNativeRequest(HttpServletRequest.class))
+                .willReturn(httpServletRequest);
+
+        given(httpServletRequest.getHeaders(HttpHeaders.AUTHORIZATION))
+                .willReturn(Collections.enumeration(List.of(wrongBearerToken)));
+
+        assertThat(authenticationArgumentResolver.resolveArgument(null, null, nativeWebRequest, null))
+                .isEqualTo(1L);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/moamoa/auth/controller/AuthenticationInterceptorTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/auth/controller/AuthenticationInterceptorTest.java
@@ -1,0 +1,76 @@
+package com.woowacourse.moamoa.auth.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.woowacourse.moamoa.auth.infrastructure.TokenProvider;
+import com.woowacourse.moamoa.common.exception.UnauthorizedException;
+import java.util.Collections;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+
+@SpringBootTest
+class AuthenticationInterceptorTest {
+
+    @MockBean
+    private HttpServletRequest httpServletRequest;
+
+    @Autowired
+    private AuthenticationInterceptor authenticationInterceptor;
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @DisplayName("Preflight 요청인지 확인한다.")
+    @Test
+    void isPreflightRequest() {
+        given(httpServletRequest.getMethod())
+                .willReturn(HttpMethod.OPTIONS.toString());
+
+        assertThat(authenticationInterceptor.preHandle(httpServletRequest, null, null)).isTrue();
+    }
+
+    @DisplayName("유효한 토큰을 검증한다.")
+    @Test
+    void validateValidToken() {
+        final String token = tokenProvider.createToken(1L);
+        String bearerToken = "Bearer " + token;
+
+        given(httpServletRequest.getMethod())
+                .willReturn(HttpMethod.POST.toString());
+        given(httpServletRequest.getServletPath())
+                .willReturn("/api/studies");
+        given(httpServletRequest.getHeaders(HttpHeaders.AUTHORIZATION))
+                .willReturn(Collections.enumeration(List.of(bearerToken)));
+
+        given(httpServletRequest.getAttribute("payload")).willReturn("1");
+
+        assertThat(authenticationInterceptor.preHandle(httpServletRequest, null, null)).isTrue();
+        assertThat(httpServletRequest.getAttribute("payload")).isEqualTo(tokenProvider.getPayload(token));
+    }
+
+    @DisplayName("유효하지 않은 토큰일 경우 예외를 던진다.")
+    @Test
+    void validateInvalidToken() {
+        String token = "Bearer " + "Invalid token";
+
+        given(httpServletRequest.getMethod())
+                .willReturn(HttpMethod.POST.toString());
+        given(httpServletRequest.getServletPath())
+                .willReturn("/api/studies");
+        given(httpServletRequest.getHeaders(HttpHeaders.AUTHORIZATION))
+                .willReturn(Collections.enumeration(List.of(token)));
+
+        assertThatThrownBy(() -> authenticationInterceptor.preHandle(httpServletRequest, null, null))
+                .isInstanceOf(UnauthorizedException.class)
+                        .hasMessageContaining("유효하지 않은 토큰입니다.");
+    }
+}

--- a/backend/src/test/java/com/woowacourse/moamoa/auth/infrastructure/TokenProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/auth/infrastructure/TokenProviderTest.java
@@ -16,12 +16,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 @SpringBootTest
-class JwtTokenProviderTest {
+class TokenProviderTest {
 
     private static final String TEST_SECRET_KEY = "9d0bd354d2a68141d2ced83c26fe3fb72046783c19e7b727a45804d7d80c96a1541f9decbc3833519bd168ff7735d15a0e0737f40b20977bece9d8c0220425a1";
 
     @Autowired
-    private JwtTokenProvider jwtTokenProvider;
+    private TokenProvider tokenProvider;
 
     @DisplayName("만료된 토큰인지 확인한다")
     @Test
@@ -43,22 +43,22 @@ class JwtTokenProviderTest {
                 .signWith(keys, SignatureAlgorithm.HS256)
                 .compact();
 
-        assertThat(jwtTokenProvider.validateToken(token)).isFalse();
+        assertThat(tokenProvider.validateToken(token)).isFalse();
     }
 
     @DisplayName("JwtToken 유효한 토큰 검증")
     @Test
     void isAvailableToken() {
-        String token = jwtTokenProvider.createToken(1L);
+        String token = tokenProvider.createToken(1L);
 
-        assertThat(jwtTokenProvider.validateToken(token)).isTrue();
+        assertThat(tokenProvider.validateToken(token)).isTrue();
     }
 
     @DisplayName("JwtToken payload 검증")
     @Test
     void getPayload() {
-        String token = jwtTokenProvider.createToken(1L);
+        String token = tokenProvider.createToken(1L);
 
-        assertThat(jwtTokenProvider.getPayload(token)).isEqualTo("1");
+        assertThat(tokenProvider.getPayload(token)).isEqualTo("1");
     }
 }

--- a/backend/src/test/java/com/woowacourse/moamoa/auth/infrastructure/TokenProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/auth/infrastructure/TokenProviderTest.java
@@ -46,19 +46,39 @@ class TokenProviderTest {
         assertThat(tokenProvider.validateToken(token)).isFalse();
     }
 
-    @DisplayName("JwtToken 유효한 토큰 검증")
+    @DisplayName("유효한 토큰을 검증한다.")
     @Test
-    void isAvailableToken() {
+    void validateTokenByValidToken() {
         String token = tokenProvider.createToken(1L);
 
         assertThat(tokenProvider.validateToken(token)).isTrue();
     }
 
-    @DisplayName("JwtToken payload 검증")
+    @DisplayName("유효하지 않은 토큰을 검증한다.")
     @Test
-    void getPayload() {
+    void validateTokenByInvalidToken() {
+        String token = tokenProvider.createToken(1L);
+
+        String invalidToken = token + "dummy";
+
+        assertThat(tokenProvider.validateToken(invalidToken)).isFalse();
+    }
+
+    @DisplayName("JwtToken payload 검증한다.")
+    @Test
+    void validatePayload() {
         String token = tokenProvider.createToken(1L);
 
         assertThat(tokenProvider.getPayload(token)).isEqualTo("1");
+    }
+    
+    @DisplayName("JwtToken 형식을 검증한다.")
+    @Test
+    void validateJwtTokenFormat() {
+        String token = tokenProvider.createToken(1L);
+
+        final String[] parts = token.split("\\.");
+
+        assertThat(parts.length).isEqualTo(3);
     }
 }

--- a/backend/src/test/java/com/woowacourse/moamoa/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/auth/service/AuthServiceTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.moamoa.auth.controller.AuthController;
-import com.woowacourse.moamoa.auth.infrastructure.JwtTokenProvider;
+import com.woowacourse.moamoa.auth.infrastructure.TokenProvider;
 import com.woowacourse.moamoa.auth.service.response.TokenResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ class AuthServiceTest {
     private AuthService authService;
 
     @MockBean
-    private JwtTokenProvider jwtTokenProvider;
+    private TokenProvider tokenProvider;
 
     @DisplayName("Authorization code를 받아서 token을 발급한다.")
     @Test


### PR DESCRIPTION
<!-- title: "[BE|FE] issue00: 제목" -->
## 요약
로그인 기능을 리팩터링한다. 

https://github.com/woowacourse-teams/2022-moamoa/issues/50
https://github.com/woowacourse-teams/2022-moamoa/pull/76

## 세부사항
- 리팩터링
  - TokenProvider 인터페이스 선언
  - TokenProvider 테스트 추가
  - Config 설정 클래스 이름 변경
  - 리졸버 TokenProvider 빈 생성자 주입으로 변경
  
- 새로 생성한 부분
  - **Authentication 인터셉터 테스트 생성**
  - **Authentication 리졸버 테스트 생성**

close 
