### PR TITLE
[BE] issue113: 스터디 필터를 통한 조회 리팩토링

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,14 +1,7 @@
-buildscript {
-    ext {
-        queryDslVersion = "5.0.0"
-    }
-}
-
 plugins {
     id 'org.springframework.boot' version '2.6.9'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
-    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.woowacourse'
@@ -41,33 +34,4 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
-
-    // querydsl
-    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
-    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
-    systemProperties = System.getProperties()
-}
-
-// querydsl
-def querydslDir = "$buildDir/generated/querydsl"
-
-querydsl {
-    jpa = true
-    querydslSourcesDir = querydslDir
-}
-sourceSets {
-    main.java.srcDir querydslDir
-}
-compileQuerydsl {
-    options.annotationProcessorPath = configurations.querydsl
-}
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-    querydsl.extendsFrom compileClasspath
 }

--- a/backend/src/main/java/com/woowacourse/moamoa/study/domain/Study.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/domain/Study.java
@@ -1,20 +1,26 @@
 package com.woowacourse.moamoa.study.domain;
 
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
 import com.woowacourse.moamoa.study.domain.exception.InvalidPeriodException;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 
 @Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
 public class Study {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
     @Embedded
@@ -40,42 +46,19 @@ public class Study {
 
     public Study(final Long id, final Details details, final Participants participants,
                  final Period period, final AttachedTags attachedTags) {
+        validatePeriod(period);
+
         this.id = id;
         this.details = details;
         this.participants = participants;
         this.period = period;
         this.createdAt = LocalDateTime.now();
         this.attachedTags = attachedTags;
+    }
 
+    private void validatePeriod(final Period period) {
         if (period.isBefore(createdAt)) {
             throw new InvalidPeriodException();
         }
-    }
-
-    protected Study() {
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public Details getDetails() {
-        return details;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
-
-    public Period getPeriod() {
-        return period;
-    }
-
-    public Participants getParticipants() {
-        return participants;
-    }
-
-    public AttachedTags getAttachedTags() {
-        return attachedTags;
     }
 }

--- a/backend/src/main/java/com/woowacourse/moamoa/study/query/SearchingTags.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/query/SearchingTags.java
@@ -1,5 +1,7 @@
 package com.woowacourse.moamoa.study.query;
 
+import static com.woowacourse.moamoa.tag.domain.CategoryName.*;
+
 import com.woowacourse.moamoa.tag.domain.CategoryName;
 import java.util.HashMap;
 import java.util.List;
@@ -14,9 +16,9 @@ public class SearchingTags {
     private final Map<CategoryName, List<Long>> tags = new HashMap<>();
 
     public SearchingTags(final List<Long> generationIds, final List<Long> areaIds, final List<Long> tagIds) {
-        tags.put(CategoryName.GENERATION, generationIds);
-        tags.put(CategoryName.AREA, areaIds);
-        tags.put(CategoryName.SUBJECT, tagIds);
+        tags.put(GENERATION, generationIds);
+        tags.put(AREA, areaIds);
+        tags.put(SUBJECT, tagIds);
     }
 
     public boolean hasBy(CategoryName name) {

--- a/backend/src/main/java/com/woowacourse/moamoa/study/query/StudyDetailsDao.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/query/StudyDetailsDao.java
@@ -7,19 +7,17 @@ import com.woowacourse.moamoa.study.service.exception.StudyNotFoundException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@RequiredArgsConstructor
 public class StudyDetailsDao {
 
     private final JdbcTemplate jdbcTemplate;
-
-    public StudyDetailsDao(final JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     public StudyDetailsData findBy(Long studyId) {
         String sql = "SELECT study.id, title, excerpt, thumbnail, status, description, current_member_count, "

--- a/backend/src/main/java/com/woowacourse/moamoa/study/query/StudySummaryDao.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/query/StudySummaryDao.java
@@ -19,21 +19,13 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class StudySummaryDao {
 
-    private static final RowMapper<StudySummaryData> ROW_MAPPER = (rs, rn) -> {
-        final Long id = rs.getLong("id");
-        final String title = rs.getString("title");
-        final String excerpt = rs.getString("excerpt");
-        final String thumbnail = rs.getString("thumbnail");
-        final String status = rs.getString("status");
-        return new StudySummaryData(id, title, excerpt, thumbnail, status);
-    };
+    private static final RowMapper<StudySummaryData> STUDY_ROW_MAPPER = createStudyRowMapper();
 
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
-    public Slice<StudySummaryData> searchBy(final String title, final SearchingTags searchingTags,
-                                            final Pageable pageable) {
+    public Slice<StudySummaryData> searchBy(final String title, final SearchingTags searchingTags, final Pageable pageable) {
         final List<StudySummaryData> data = namedParameterJdbcTemplate
-                .query(sql(searchingTags), params(title, searchingTags, pageable), ROW_MAPPER);
+                .query(sql(searchingTags), params(title, searchingTags, pageable), STUDY_ROW_MAPPER);
         return new SliceImpl<>(getCurrentPageStudies(data, pageable), pageable, hasNext(data, pageable));
 
     }
@@ -89,5 +81,18 @@ public class StudySummaryDao {
 
     private boolean hasNext(final List<StudySummaryData> studies, final Pageable pageable) {
         return studies.size() > pageable.getPageSize();
+    }
+
+    private static RowMapper<StudySummaryData> createStudyRowMapper() {
+        return (resultSet, rowNum) -> {
+            final Long id = resultSet.getLong("id");
+
+            final String title = resultSet.getString("title");
+            final String excerpt = resultSet.getString("excerpt");
+            final String thumbnail = resultSet.getString("thumbnail");
+            final String status = resultSet.getString("status");
+
+            return new StudySummaryData(id, title, excerpt, thumbnail, status);
+        };
     }
 }

--- a/backend/src/main/java/com/woowacourse/moamoa/study/service/CreateStudyService.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/service/CreateStudyService.java
@@ -34,6 +34,7 @@ public class CreateStudyService {
         final Details details = request.mapToDetails();
         final Period period = request.mapToPeriod();
         final AttachedTags attachedTags = request.mapToAttachedTags();
+
         return studyRepository.save(new Study(details, participants, period, attachedTags));
     }
 


### PR DESCRIPTION
## 요약

스터디 필터를 통한 조회 리팩토링

## 세부사항

### 리팩토링 사유
- `CQRS` 를 지키기 위해서
-  중간에 `StudyTag` 라고 하는 객체지향적이지 않은 클래스의 제거
- 패키지 구조 변경 시에 Querydsl 을 위해서 빌드를 새롭게 해주어야하는 번거로움

close #113 
