### PR TITLE
[FE] issue208: 사용자 정보 조회 적용

### DIFF
--- a/frontend/src/api/getUserInformation.ts
+++ b/frontend/src/api/getUserInformation.ts
@@ -1,0 +1,10 @@
+import type { GetUserInformation } from '@custom-types';
+
+import { axiosInstance } from '@api';
+
+const getUserInformation = async () => {
+  const response = await axiosInstance.get<GetUserInformation>(`/api/members/me`);
+  return response.data;
+};
+
+export default getUserInformation;

--- a/frontend/src/context/login/LoginProvider.tsx
+++ b/frontend/src/context/login/LoginProvider.tsx
@@ -1,8 +1,10 @@
-import { ReactNode, createContext, useState } from 'react';
+import { ReactNode, createContext, useEffect, useState } from 'react';
 
 import { ACCESS_TOKEN_KEY } from '@constants';
 
 import { noop } from '@utils';
+
+import { useUserInfo } from '@hooks/useUserInfo';
 
 type LoginProviderProps = {
   children: ReactNode;
@@ -22,5 +24,13 @@ export const LoginContext = createContext<ContextType>({
 
 export const LoginProvider = ({ children }: LoginProviderProps) => {
   const [isLoggedIn, setIsLoggedIn] = useState(hasAccessToken);
+  const { fetchUserInfo } = useUserInfo();
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      fetchUserInfo();
+    }
+  }, []);
+
   return <LoginContext.Provider value={{ isLoggedIn, setIsLoggedIn }}>{children}</LoginContext.Provider>;
 };

--- a/frontend/src/context/userInfo/UserInfoProvider.tsx
+++ b/frontend/src/context/userInfo/UserInfoProvider.tsx
@@ -1,0 +1,26 @@
+import { ReactNode, createContext, useState } from 'react';
+
+import { noop } from '@utils';
+
+import type { Member } from '@custom-types';
+
+type LoginProviderProps = {
+  children: ReactNode;
+};
+
+type ContextType = {
+  userInfo: Member;
+  setUserInfo: React.Dispatch<React.SetStateAction<Member>>;
+};
+
+const initialValue = { id: -1, username: '', imageUrl: '', profileUrl: '' };
+
+export const UserInfoContext = createContext<ContextType>({
+  userInfo: initialValue,
+  setUserInfo: noop,
+});
+
+export const UserInfoProvider = ({ children }: LoginProviderProps) => {
+  const [userInfo, setUserInfo] = useState<Member>(initialValue);
+  return <UserInfoContext.Provider value={{ userInfo, setUserInfo }}>{children}</UserInfoContext.Provider>;
+};

--- a/frontend/src/custom-types/index.ts
+++ b/frontend/src/custom-types/index.ts
@@ -172,3 +172,5 @@ export type PostNewStudyRequestBody = {
   >,
   'maxMemberCount' | 'enrollmentEndDate' | 'endDate' | 'owner'
 >;
+
+export type GetUserInformation = Member;

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -4,12 +4,16 @@ import { ACCESS_TOKEN_KEY } from '@constants';
 
 import { LoginContext } from '@context/login/LoginProvider';
 
+import { useUserInfo } from './useUserInfo';
+
 export const useAuth = () => {
   const { isLoggedIn, setIsLoggedIn } = useContext(LoginContext);
+  const { fetchUserInfo } = useUserInfo();
 
   const login = (accesssToken: string) => {
     window.sessionStorage.setItem(ACCESS_TOKEN_KEY, accesssToken);
     setIsLoggedIn(true);
+    fetchUserInfo();
   };
 
   const logout = () => {

--- a/frontend/src/hooks/useUserInfo.ts
+++ b/frontend/src/hooks/useUserInfo.ts
@@ -1,0 +1,25 @@
+import { useContext, useEffect } from 'react';
+import { useQuery } from 'react-query';
+
+import type { GetUserInformation } from '@custom-types';
+
+import getUserInformation from '@api/getUserInformation';
+
+import { UserInfoContext } from '@context/userInfo/UserInfoProvider';
+
+export const useUserInfo = () => {
+  const { userInfo, setUserInfo } = useContext(UserInfoContext);
+  const { data, refetch: fetchUserInfo } = useQuery<GetUserInformation, Error>('user-info', getUserInformation, {
+    enabled: false,
+  });
+
+  useEffect(() => {
+    if (!data) return;
+    setUserInfo(data);
+  }, [data]);
+
+  return {
+    fetchUserInfo,
+    userInfo,
+  };
+};

--- a/frontend/src/hooks/useUserInfo.ts
+++ b/frontend/src/hooks/useUserInfo.ts
@@ -9,12 +9,17 @@ import { UserInfoContext } from '@context/userInfo/UserInfoProvider';
 
 export const useUserInfo = () => {
   const { userInfo, setUserInfo } = useContext(UserInfoContext);
-  const { data, refetch: fetchUserInfo } = useQuery<GetUserInformation, Error>('user-info', getUserInformation, {
+  const {
+    data,
+    refetch: fetchUserInfo,
+    isError,
+    isSuccess,
+  } = useQuery<GetUserInformation, Error>('user-info', getUserInformation, {
     enabled: false,
   });
 
   useEffect(() => {
-    if (!data) return;
+    if (!data || isError || !isSuccess) return;
     setUserInfo(data);
   }, [data]);
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -9,6 +9,7 @@ import { theme } from '@styles/theme';
 
 import { LoginProvider } from '@context/login/LoginProvider';
 import { SearchProvider } from '@context/search/SearchProvider';
+import { UserInfoProvider } from '@context/userInfo/UserInfoProvider';
 
 import App from './App';
 
@@ -31,14 +32,16 @@ if ($root) {
   root.render(
     <ThemeProvider theme={theme}>
       <QueryClientProvider client={queryClient}>
-        <LoginProvider>
-          <SearchProvider>
-            <GlobalStyles />
-            <BrowserRouter>
-              <App />
-            </BrowserRouter>
-          </SearchProvider>
-        </LoginProvider>
+        <UserInfoProvider>
+          <LoginProvider>
+            <SearchProvider>
+              <GlobalStyles />
+              <BrowserRouter>
+                <App />
+              </BrowserRouter>
+            </SearchProvider>
+          </LoginProvider>
+        </UserInfoProvider>
       </QueryClientProvider>
     </ThemeProvider>,
   );

--- a/frontend/src/layout/header/Header.tsx
+++ b/frontend/src/layout/header/Header.tsx
@@ -6,6 +6,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { PATH, PROFILE_IMAGE_URL } from '@constants';
 
 import { useAuth } from '@hooks/useAuth';
+import { useUserInfo } from '@hooks/useUserInfo';
 
 import { SearchContext } from '@context/search/SearchProvider';
 
@@ -29,6 +30,7 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
   const navigate = useNavigate();
 
   const { logout, isLoggedIn } = useAuth();
+  const { userInfo } = useUserInfo();
 
   const handleKeywordSubmit = (e: React.FormEvent<HTMLFormElement>, inputName: string) => {
     e.preventDefault();
@@ -61,11 +63,7 @@ const Header: React.FC<HeaderProps> = ({ className }) => {
             </NavButton>
           </Link>
           <S.AvatarButton onClick={handleAvatarButtonClick}>
-            <Avatar
-              // TODO: Context에서 정보를 가져온다
-              profileImg={PROFILE_IMAGE_URL}
-              profileAlt="프로필 이미지"
-            />
+            <Avatar profileImg={userInfo.imageUrl} profileAlt={`${userInfo.username} 이미지`} />
           </S.AvatarButton>
           {openDropDownBox && (
             <DropDownBox top={'70px'} right={'50px'} onOutOfBoxClick={handleOutsideDropBoxClick}>

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,6 +1,7 @@
 import { rest } from 'msw';
 
 import detailStudyHandlers from '@mocks/detailStudyHandlers';
+import { memberHandlers } from '@mocks/memberHandlers';
 import { myHandlers } from '@mocks/myHandlers';
 import { reviewHandlers } from '@mocks/reviewHandler';
 import studyJSON from '@mocks/studies.json';
@@ -93,4 +94,5 @@ export const handlers = [
   ...myHandlers,
   ...reviewHandlers,
   ...tokenHandlers,
+  ...memberHandlers,
 ];

--- a/frontend/src/mocks/memberHandlers.ts
+++ b/frontend/src/mocks/memberHandlers.ts
@@ -1,0 +1,15 @@
+import { rest } from 'msw';
+
+const user = {
+  id: 20,
+  username: 'tco0427',
+  imageUrl:
+    'https://images.unsplash.com/flagged/photo-1570612861542-284f4c12e75f?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2070&q=80',
+  profileUrl: 'github.com',
+};
+
+export const memberHandlers = [
+  rest.get('/api/members/me', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(user));
+  }),
+];

--- a/frontend/src/pages/detail-page/components/study-float-box/StudyFloatBox.tsx
+++ b/frontend/src/pages/detail-page/components/study-float-box/StudyFloatBox.tsx
@@ -30,7 +30,7 @@ const StudyFloatBox: React.FC<StudyFloatBoxProps> = ({
     }
 
     if (!enrollmentEndDate) {
-      return '모집중';
+      return <span>모집중</span>;
     }
 
     return (

--- a/frontend/src/pages/detail-page/components/study-wide-float-box/StudyWideFloatBox.tsx
+++ b/frontend/src/pages/detail-page/components/study-wide-float-box/StudyWideFloatBox.tsx
@@ -31,7 +31,7 @@ const StudyWideFloatBox: React.FC<StudyWideFloatBoxProps> = ({
     }
 
     if (!enrollmentEndDate) {
-      return '모집중';
+      return <span>모집중</span>;
     }
 
     return (

--- a/frontend/src/pages/study-room-page/components/review-tab-panel/ReviewTabPanel.tsx
+++ b/frontend/src/pages/study-room-page/components/review-tab-panel/ReviewTabPanel.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { useUserInfo } from '@hooks/useUserInfo';
 
 import Divider from '@components/divider/Divider';
@@ -15,7 +17,11 @@ export type ReviewTabPanelProps = {
 
 const ReviewTabPanel: React.FC<ReviewTabPanelProps> = ({ studyId }) => {
   const { data, isFetching, refetch, isError, isSuccess } = useGetStudyReviews(studyId);
-  const { userInfo: author } = useUserInfo();
+  const { userInfo: author, fetchUserInfo } = useUserInfo();
+
+  useEffect(() => {
+    fetchUserInfo();
+  }, []);
 
   const handlePostSuccess = () => {
     alert('댓글을 추가했습니다');

--- a/frontend/src/pages/study-room-page/components/review-tab-panel/ReviewTabPanel.tsx
+++ b/frontend/src/pages/study-room-page/components/review-tab-panel/ReviewTabPanel.tsx
@@ -1,4 +1,4 @@
-import type { Member } from '@custom-types';
+import { useUserInfo } from '@hooks/useUserInfo';
 
 import Divider from '@components/divider/Divider';
 import Wrapper from '@components/wrapper/Wrapper';
@@ -15,14 +15,7 @@ export type ReviewTabPanelProps = {
 
 const ReviewTabPanel: React.FC<ReviewTabPanelProps> = ({ studyId }) => {
   const { data, isFetching, refetch, isError, isSuccess } = useGetStudyReviews(studyId);
-  const author: Member = {
-    id: 1,
-    profileUrl: 'https://github.com/airman5573',
-    imageUrl: 'https://cdn.mos.cms.futurecdn.net/yCPyoZDQBBcXikqxkeW2jJ-1200-80.jpg',
-    username: 'earth',
-  };
-
-  const hasReviews = !!data?.reviews;
+  const { userInfo: author } = useUserInfo();
 
   const handlePostSuccess = () => {
     alert('댓글을 추가했습니다');

--- a/frontend/src/pages/study-room-page/components/review-tab-panel/components/reivew-form/ReviewForm.tsx
+++ b/frontend/src/pages/study-room-page/components/review-tab-panel/components/reivew-form/ReviewForm.tsx
@@ -53,8 +53,8 @@ const ReviewForm: React.FC<ReviewFormProps> = ({ studyId, author, onPostSuccess,
     <S.ReviewForm onSubmit={handleSubmit(onSubmit)}>
       <S.ReviewFormHead>
         <S.UserInfo href={author.profileUrl}>
-          <Avatar profileImg={author.imageUrl} profileAlt="EMPTY" size="xs" />
-          <S.Username>rpf5573</S.Username>
+          <Avatar profileImg={author.imageUrl} profileAlt={`${author.username} 이미지`} size="xs" />
+          <S.Username>{author.username}</S.Username>
         </S.UserInfo>
       </S.ReviewFormHead>
       <S.ReviewFormBody>


### PR DESCRIPTION
<!-- title: "[BE|FE] issue00: 제목" -->
## 요약
헤더와 후기 작성란에서 사용자 정보 조회

## 세부사항
- 후기 작성란이 렌더링될 때 다시 사용자 정보를 조회하도록 했습니다.
- 사용자 정보를 조회할 때 에러가 발생하면 사용자 정보 상태를 갱신하지 않도록 했는데 (그냥 return;) 다른 좋은 방법이 있을까요?

close #208 
