### PR TITLE
[BE] issue252: 링크 공유 설명란 최대 글자수 40자로 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/moamoa/referenceroom/service/request/CreatingLinkRequest.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/referenceroom/service/request/CreatingLinkRequest.java
@@ -18,7 +18,7 @@ public class CreatingLinkRequest {
     @Size(max = 500, message = "링크 URL은 500자를 초과할 수 없습니다.")
     private String linkUrl;
 
-    @Size(max = 25, message = "설명은 25자를 초과할 수 없습니다.")
+    @Size(max = 40, message = "설명은 40자를 초과할 수 없습니다.")
     private String description;
 
     public Link toLink(final Long studyId, final Long memberId) {

--- a/backend/src/main/java/com/woowacourse/moamoa/referenceroom/service/request/EditingLinkRequest.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/referenceroom/service/request/EditingLinkRequest.java
@@ -18,7 +18,7 @@ public class EditingLinkRequest {
     @Size(max = 500, message = "링크 URL은 500자를 초과할 수 없습니다.")
     private String linkUrl;
 
-    @Size(max = 25, message = "설명은 25자를 초과할 수 없습니다.")
+    @Size(max = 40, message = "설명은 40자를 초과할 수 없습니다.")
     private String description;
 
     public Link toLink(final Long studyId, final Long memberId) {

--- a/backend/src/test/java/com/woowacourse/moamoa/referenceroom/webmvc/ReferenceRoomWebMvcTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/referenceroom/webmvc/ReferenceRoomWebMvcTest.java
@@ -42,9 +42,9 @@ public class ReferenceRoomWebMvcTest extends WebMVCTest {
                 .andExpect(status().isBadRequest());
     }
 
-    @DisplayName("링크 공유 설명이 25글자 이상인 경우 400을 반환한다.")
+    @DisplayName("링크 공유 설명이 40글자 이상인 경우 400을 반환한다.")
     @Test
-    void requestBy25LengthExceededDescription() throws Exception {
+    void requestBy40LengthExceededDescription() throws Exception {
         final String token = "Bearer " + tokenProvider.createToken(1L).getAccessToken();
         final String content = objectMapper.writeValueAsString(new CreatingLinkRequest("링크",
                 "일이삼사오육칠팔구십"


### PR DESCRIPTION
<!-- title: "[BE|FE] issue00: 제목" -->
## 요약

링크공유 생성 및 수정 시 설명란 최대 글자수 40글자로 변경

## 세부사항

링크공유를 생성 또는 수정하는 경우 작성할 수 있는 최대 설명 글자수 25자에서 40자로 변경

close #252 
