### PR TITLE
[BE] issue: 266: Interceptor refresh 요청 제외

### DIFF
--- a/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthenticationInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthenticationInterceptor.java
@@ -2,7 +2,6 @@ package com.woowacourse.moamoa.auth.controller;
 
 import com.woowacourse.moamoa.auth.config.AuthenticationExtractor;
 import com.woowacourse.moamoa.auth.controller.matcher.AuthenticationRequestMatcher;
-import com.woowacourse.moamoa.auth.controller.matcher.AuthenticationRequestMatcherBuilder;
 import com.woowacourse.moamoa.auth.infrastructure.TokenProvider;
 import com.woowacourse.moamoa.common.exception.UnauthorizedException;
 
@@ -30,7 +29,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
         if (authenticationRequestMatcher.isRequiredAuth(request)) {
             final String token = AuthenticationExtractor.extract(request);
-            validateToken(token);
+            validateToken(token, request.getRequestURI());
 
             request.setAttribute("payload", tokenProvider.getPayload(token));
         }
@@ -42,7 +41,10 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         return HttpMethod.OPTIONS.matches(request.getMethod());
     }
 
-    private void validateToken(String token) {
+    private void validateToken(String token, String requestURI) {
+        if (requestURI.equals("/api/auth/refresh") && token != null) {
+            return;
+        }
         if (token == null || !tokenProvider.validateToken(token)) {
             throw new UnauthorizedException("유효하지 않은 토큰입니다.");
         }


### PR DESCRIPTION
## 요약

refresh 요청시 401 에러

## 세부사항

Interceptor 에서 access 토큰의 만료기간을 refresh 때에도 검사하여, refresh 가 제대로 이루어지지 못하는 문제 발생

close #266 
