### PR TITLE
[BE] fix: refreshToken 로직 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/moamoa/auth/config/AuthConfig.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/config/AuthConfig.java
@@ -1,6 +1,7 @@
 package com.woowacourse.moamoa.auth.config;
 
 import com.woowacourse.moamoa.auth.controller.AuthenticatedMemberResolver;
+import com.woowacourse.moamoa.auth.controller.AuthenticatedRefreshArgumentResolver;
 import com.woowacourse.moamoa.auth.controller.AuthenticationArgumentResolver;
 import com.woowacourse.moamoa.auth.controller.AuthenticationInterceptor;
 
@@ -18,6 +19,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class AuthConfig implements WebMvcConfigurer {
 
+    private final AuthenticatedRefreshArgumentResolver authenticatedRefreshArgumentResolver;
     private final AuthenticationInterceptor authenticationInterceptor;
     private final AuthenticationArgumentResolver authenticationArgumentResolver;
     private final AuthenticatedMemberResolver authenticatedMemberResolver;
@@ -26,6 +28,7 @@ public class AuthConfig implements WebMvcConfigurer {
     public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authenticationArgumentResolver);
         resolvers.add(authenticatedMemberResolver);
+        resolvers.add(authenticatedRefreshArgumentResolver);
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/moamoa/auth/config/AuthRequestMatchConfig.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/config/AuthRequestMatchConfig.java
@@ -23,6 +23,7 @@ public class AuthRequestMatchConfig {
                         "/api/studies")
                 .addUpAuthenticationPath(GET,
                         "/api/my/studies",
+                        "/api/auth/refresh",
                         "/api/members/me",
                         "/api/members/me/role",
                         "/api/studies/\\w+/community/articles/\\w+",

--- a/backend/src/main/java/com/woowacourse/moamoa/auth/config/AuthenticatedRefresh.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/config/AuthenticatedRefresh.java
@@ -1,0 +1,11 @@
+package com.woowacourse.moamoa.auth.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticatedRefresh {
+}

--- a/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moamoa.auth.controller;
 
+import com.woowacourse.moamoa.auth.config.AuthenticatedRefresh;
 import com.woowacourse.moamoa.auth.config.AuthenticationPrincipal;
 import com.woowacourse.moamoa.auth.service.AuthService;
 import com.woowacourse.moamoa.auth.service.response.AccessTokenResponse;
@@ -34,7 +35,7 @@ public class AuthController {
     }
 
     @GetMapping("/api/auth/refresh")
-    public ResponseEntity<AccessTokenResponse> refreshToken(@AuthenticationPrincipal Long githubId, @CookieValue String refreshToken) {
+    public ResponseEntity<AccessTokenResponse> refreshToken(@AuthenticatedRefresh Long githubId, @CookieValue String refreshToken) {
         return ResponseEntity.ok().body(authService.refreshToken(githubId, refreshToken));
     }
 

--- a/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthenticatedRefreshArgumentResolver.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthenticatedRefreshArgumentResolver.java
@@ -1,0 +1,39 @@
+package com.woowacourse.moamoa.auth.controller;
+
+import com.woowacourse.moamoa.auth.config.AuthenticatedRefresh;
+import com.woowacourse.moamoa.auth.config.AuthenticationExtractor;
+import com.woowacourse.moamoa.auth.infrastructure.TokenProvider;
+import com.woowacourse.moamoa.common.exception.UnauthorizedException;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticatedRefreshArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticatedRefresh.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
+        final HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        final String token = AuthenticationExtractor.extract(request);
+
+        if (token == null) {
+            throw new UnauthorizedException("인증 타입이 올바르지 않습니다.");
+        }
+
+        return Long.valueOf(tokenProvider.getPayloadWithExpiredToken(token));
+    }
+}

--- a/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthenticationInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/controller/AuthenticationInterceptor.java
@@ -31,7 +31,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
             final String token = AuthenticationExtractor.extract(request);
             validateToken(token, request.getRequestURI());
 
-            request.setAttribute("payload", tokenProvider.getPayload(token));
+            request.setAttribute("payload", token);
         }
 
         return true;

--- a/backend/src/main/java/com/woowacourse/moamoa/auth/infrastructure/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/infrastructure/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.woowacourse.moamoa.auth.infrastructure;
 import com.woowacourse.moamoa.auth.exception.RefreshTokenExpirationException;
 import com.woowacourse.moamoa.auth.service.response.TokensResponse;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -58,6 +59,20 @@ public class JwtTokenProvider implements TokenProvider {
                 .parseClaimsJws(token)
                 .getBody()
                 .getSubject();
+    }
+
+    @Override
+    public String getPayloadWithExpiredToken(final String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getSubject();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims().getSubject();
+        }
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/moamoa/auth/infrastructure/TokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/auth/infrastructure/TokenProvider.java
@@ -8,6 +8,8 @@ public interface TokenProvider {
 
     String getPayload(final String token);
 
+    String getPayloadWithExpiredToken(final String token);
+
     boolean validateToken(final String token);
 
     String recreationAccessToken(final Long githubId, final String refreshToken);

--- a/backend/src/test/java/com/woowacourse/acceptance/test/referenceroom/ReferenceRoomAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/acceptance/test/referenceroom/ReferenceRoomAcceptanceTest.java
@@ -118,7 +118,7 @@ class ReferenceRoomAcceptanceTest extends AcceptanceTest {
                         )))
                 .header(HttpHeaders.AUTHORIZATION, token)
                 .pathParam("study-id", 자바_스터디_ID)
-                .param("page", 1)
+                .param("page", 0)
                 .param("size", 5)
                 .when().log().all()
                 .get("/api/studies/{study-id}/reference-room/links")


### PR DESCRIPTION
## 요약

refreshToken 로직 수정

## 세부사항

"api/auth/refresh" 요청 시에는 accessToken의 유효성 검증이 불필요하다.
