### PR TITLE
[BE] issue359: 기존 githubId 사용하던 곳 모두 memberId 로 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/moamoa/member/query/MemberDao.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/member/query/MemberDao.java
@@ -25,7 +25,7 @@ public class MemberDao {
     }
 
     public List<ParticipatingMemberData> findMembersByStudyId(final Long studyId) {
-        final String sql = "SELECT member.id, github_id, username, image_url, profile_url, "
+        final String sql = "SELECT member.id as member_id, username, image_url, profile_url, "
                 + "study_member.participation_date as participation_date, "
                 + countStudyNumber()
                 + "FROM member JOIN study_member ON member.id = study_member.member_id "
@@ -63,13 +63,13 @@ public class MemberDao {
 
     private static RowMapper<ParticipatingMemberData> createMemberFullDataRowMapper() {
         return (resultSet, resultNumber) -> {
-            Long githubId = resultSet.getLong("github_id");
+            Long id = resultSet.getLong("member_id");
             String username = resultSet.getString("username");
             String imageUrl = resultSet.getString("image_url");
             String profileUrl = resultSet.getString("profile_url");
             LocalDate participationDate = resultSet.getDate("participation_date").toLocalDate();
             int numberOfStudy = resultSet.getInt("number_of_study");
-            return new ParticipatingMemberData(githubId, username, imageUrl, profileUrl, participationDate, numberOfStudy);
+            return new ParticipatingMemberData(id, username, imageUrl, profileUrl, participationDate, numberOfStudy);
         };
     }
 

--- a/backend/src/main/java/com/woowacourse/moamoa/member/query/data/OwnerData.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/member/query/data/OwnerData.java
@@ -2,7 +2,6 @@ package com.woowacourse.moamoa.member.query.data;
 
 import static lombok.AccessLevel.PRIVATE;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -17,8 +16,7 @@ import lombok.ToString;
 @ToString
 public class OwnerData {
 
-    @JsonProperty("id")
-    private Long githubId;
+    private Long id;
 
     private String username;
 

--- a/backend/src/main/java/com/woowacourse/moamoa/member/query/data/ParticipatingMemberData.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/member/query/data/ParticipatingMemberData.java
@@ -16,8 +16,7 @@ import lombok.ToString;
 @ToString
 public class ParticipatingMemberData {
 
-    @JsonProperty("id")
-    private Long githubId;
+    private Long id;
 
     private String username;
 

--- a/backend/src/main/java/com/woowacourse/moamoa/referenceroom/query/LinkDao.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/referenceroom/query/LinkDao.java
@@ -21,7 +21,7 @@ public class LinkDao {
 
     public Slice<LinkData> findAllByStudyId(final Long studyId, final Pageable pageable) {
         final String sql = "SELECT link.id, link.link_url, link.description, link.created_date, link.last_modified_date, "
-                + "member.github_id, member.username, member.image_url, member.profile_url "
+                + "member.id as member_id, member.username, member.image_url, member.profile_url "
                 + "FROM link "
                 + "JOIN member ON link.member_id = member.id "
                 + "WHERE link.deleted = false "
@@ -55,11 +55,11 @@ public class LinkDao {
             final LocalDate createdDate = rs.getObject("created_date", LocalDate.class);
             final LocalDate lastModifiedDate = rs.getObject("last_modified_date", LocalDate.class);
 
-            final Long githubId = rs.getLong("github_id");
+            final Long memberId = rs.getLong("member_id");
             final String username = rs.getString("username");
             final String imageUrl = rs.getString("image_url");
             final String profileUrl = rs.getString("profile_url");
-            final MemberData memberData = new MemberData(githubId, username, imageUrl, profileUrl);
+            final MemberData memberData = new MemberData(memberId, username, imageUrl, profileUrl);
 
             return new LinkData(id, memberData, linkUrl, description, createdDate, lastModifiedDate);
         };

--- a/backend/src/main/java/com/woowacourse/moamoa/review/query/ReviewDao.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/review/query/ReviewDao.java
@@ -18,7 +18,7 @@ public class ReviewDao {
 
     public List<ReviewData> findAllByStudyId(final Long studyId) {
         String sql = "SELECT review.id, review.content, review.created_date, review.last_modified_date, "
-                + "member.github_id, member.username, member.image_url, member.profile_url "
+                + "member.id as member_id, member.username, member.image_url, member.profile_url "
                 + "FROM review JOIN member ON review.member_id = member.id "
                 + "WHERE review.deleted = false "
                 + "AND review.study_id = :studyId "
@@ -33,11 +33,11 @@ public class ReviewDao {
             final String content = rs.getString("content");
             final LocalDate createdDate = rs.getObject("created_date", LocalDate.class);
             final LocalDate lastModifiedDate = rs.getObject("last_modified_date", LocalDate.class);
-            final Long githubId = rs.getLong("github_id");
+            final Long memberId = rs.getLong("member_id");
             final String username = rs.getString("username");
             final String imageUrl = rs.getString("image_url");
             final String profileUrl = rs.getString("profile_url");
-            return new ReviewData(reviewId, new MemberData(githubId, username, imageUrl, profileUrl),
+            return new ReviewData(reviewId, new MemberData(memberId, username, imageUrl, profileUrl),
                     createdDate, lastModifiedDate, content);
         };
     }

--- a/backend/src/main/java/com/woowacourse/moamoa/study/query/StudyDetailsDao.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/query/StudyDetailsDao.java
@@ -26,7 +26,7 @@ public class StudyDetailsDao {
             String sql =
                     "SELECT study.id, title, excerpt, thumbnail, recruitment_status, description, current_member_count, "
                             + "max_member_count, created_at, enrollment_end_date, start_date, end_date, owner_id, "
-                            + "member.github_id as owner_github_id, member.username as owner_username, "
+                            + "member.id as owner_id, member.username as owner_username, "
                             + "member.image_url as owner_image_url, member.profile_url as owner_profile_url, created_at as participation_date, "
                             + countOfStudy()
                             + "FROM study JOIN member ON study.owner_id = member.id "
@@ -91,7 +91,7 @@ public class StudyDetailsDao {
             Integer currentMaxCount = rs.getObject("current_member_count", Integer.class);
             Integer maxMemberCount = rs.getObject("max_member_count", Integer.class);
 
-            Long githubId = rs.getLong("owner_github_id");
+            Long ownerId = rs.getLong("owner_id");
             String username = rs.getString("owner_username");
             String imageUrl = rs.getString("owner_image_url");
             String profileUrl = rs.getString("owner_profile_url");
@@ -101,7 +101,7 @@ public class StudyDetailsDao {
 
             builder.currentMemberCount(currentMaxCount)
                     .maxMemberCount(maxMemberCount)
-                    .owner(new OwnerData(githubId, username, imageUrl, profileUrl, participationDate, numberOfStudy));
+                    .owner(new OwnerData(ownerId, username, imageUrl, profileUrl, participationDate, numberOfStudy));
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/moamoa/studyroom/query/ArticleDao.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/studyroom/query/ArticleDao.java
@@ -24,11 +24,11 @@ public class ArticleDao {
         final LocalDate createdDate = rs.getObject("article_created_date", LocalDate.class);
         final LocalDate lastModifiedDate = rs.getObject("article_last_modified_date", LocalDate.class);
 
-        final long githubId = rs.getLong("member.github_id");
+        final long memberId = rs.getLong("member.id");
         final String username = rs.getString("member.username");
         final String imageUrl = rs.getString("member.image_url");
         final String profileUrl = rs.getString("member.profile_url");
-        MemberData memberData = new MemberData(githubId, username, imageUrl, profileUrl);
+        MemberData memberData = new MemberData(memberId, username, imageUrl, profileUrl);
 
         return new ArticleData(id, memberData, title, content, createdDate, lastModifiedDate);
     };
@@ -42,7 +42,7 @@ public class ArticleDao {
     public Optional<ArticleData> getById(final Long articleId, ArticleType type) {
         final String sql = "SELECT {}.id as article_id, {}.title as article_title, {}.content as article_content, "
                 + "{}.created_date as article_created_date, {}.last_modified_date as article_last_modified_date, "
-                + "member.github_id, member.username, member.image_url, member.profile_url "
+                + "member.id, member.username, member.image_url, member.profile_url "
                 + "FROM {} JOIN member ON {}.author_id = member.id "
                 + "WHERE {}.id = :{}Id";
 
@@ -59,7 +59,7 @@ public class ArticleDao {
     private List<ArticleData> getContent(final Long studyId, final Pageable pageable, ArticleType type) {
         final String sql = "SELECT {}.id as article_id, {}.title as article_title, {}.content as article_content, "
                 + "{}.created_date as article_created_date, {}.last_modified_date as article_last_modified_date, "
-                + "member.github_id, member.username, member.image_url, member.profile_url "
+                + "member.id, member.username, member.image_url, member.profile_url "
                 + "FROM {} JOIN member ON {}.author_id = member.id "
                 + "WHERE {}.study_id = :studyId "
                 + "ORDER BY created_date DESC, {}.id DESC "

--- a/backend/src/test/java/com/woowacourse/acceptance/test/referenceroom/ReferenceRoomAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/acceptance/test/referenceroom/ReferenceRoomAcceptanceTest.java
@@ -1,18 +1,14 @@
 package com.woowacourse.acceptance.test.referenceroom;
 
-import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_깃허브_ID;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_이름;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_이미지_URL;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_프로필_URL;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.디우_깃허브_ID;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.디우_이름;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.디우_이미지_URL;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.디우_프로필_URL;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.베루스_깃허브_ID;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.베루스_이름;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.베루스_이미지_URL;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.베루스_프로필_URL;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.짱구_깃허브_ID;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.짱구_이름;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.짱구_이미지_URL;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.짱구_프로필_URL;
@@ -30,6 +26,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import com.woowacourse.acceptance.AcceptanceTest;
+import com.woowacourse.moamoa.member.service.response.MemberResponse;
 import com.woowacourse.moamoa.referenceroom.service.request.CreatingLinkRequest;
 import com.woowacourse.moamoa.referenceroom.service.request.EditingLinkRequest;
 import com.woowacourse.moamoa.referenceroom.service.response.AuthorResponse;
@@ -128,22 +125,24 @@ class ReferenceRoomAcceptanceTest extends AcceptanceTest {
         final LocalDate 리뷰_생성일 = LocalDate.now();
         final LocalDate 리뷰_수정일 = LocalDate.now();
 
-        final AuthorResponse 짱구 = new AuthorResponse(짱구_깃허브_ID, 짱구_이름, 짱구_이미지_URL, 짱구_프로필_URL);
-        final LinkResponse 짱구_응답
-                = new LinkResponse(짱구_링크공유_ID, 짱구, request1.getLinkUrl(), request1.getDescription(), 리뷰_생성일, 리뷰_수정일);
+        final MemberResponse 짱구_정보 = 짱구가().로그인하고().정보를_가져온다();
+        final MemberResponse 디우_정보 = 디우가().로그인하고().정보를_가져온다();
+        final MemberResponse 그린론_정보 = 그린론이().로그인하고().정보를_가져온다();
+        final MemberResponse 베루스_정보 = 베루스가().로그인하고().정보를_가져온다();
 
-        final AuthorResponse 그린론 = new AuthorResponse(그린론_깃허브_ID, 그린론_이름, 그린론_이미지_URL, 그린론_프로필_URL);
+        final AuthorResponse 그린론 = new AuthorResponse(그린론_정보.getId(), 그린론_이름, 그린론_이미지_URL, 그린론_프로필_URL);
         final LinkResponse 그린론_응답
                 = new LinkResponse(그린론_링크공유_ID, 그린론, request2.getLinkUrl(), request2.getDescription(), 리뷰_생성일, 리뷰_수정일);
 
-        final AuthorResponse 디우 = new AuthorResponse(디우_깃허브_ID, 디우_이름, 디우_이미지_URL, 디우_프로필_URL);
+        final AuthorResponse 디우 = new AuthorResponse(디우_정보.getId(), 디우_이름, 디우_이미지_URL, 디우_프로필_URL);
         final LinkResponse 디우_응답
                 = new LinkResponse(디우_링크공유_ID, 디우, request3.getLinkUrl(), request3.getDescription(), 리뷰_생성일, 리뷰_수정일);
 
-        final AuthorResponse 베루스 = new AuthorResponse(베루스_깃허브_ID, 베루스_이름, 베루스_이미지_URL, 베루스_프로필_URL);
+        final AuthorResponse 베루스 = new AuthorResponse(베루스_정보.getId(), 베루스_이름, 베루스_이미지_URL, 베루스_프로필_URL);
         final LinkResponse 베루스_응답
                 = new LinkResponse(베루스_링크공유_ID, 베루스, request4.getLinkUrl(), request4.getDescription(), 리뷰_생성일, 리뷰_수정일);
 
+        final AuthorResponse 짱구 = new AuthorResponse(짱구_정보.getId(), 짱구_이름, 짱구_이미지_URL, 짱구_프로필_URL);
         final LinkResponse 짱구_응답2
                 = new LinkResponse(짱구_링크공유_ID2, 짱구, request1.getLinkUrl(), request1.getDescription(), 리뷰_생성일, 리뷰_수정일);
 
@@ -197,7 +196,8 @@ class ReferenceRoomAcceptanceTest extends AcceptanceTest {
         final LocalDate 링크_생성일 = 지금;
         final LocalDate 링크_수정일 = 지금;
 
-        final AuthorResponse 짱구 = new AuthorResponse(짱구_깃허브_ID, 짱구_이름, 짱구_이미지_URL, 짱구_프로필_URL);
+        final MemberResponse 짱구_정보 = 짱구가().로그인하고().정보를_가져온다();
+        final AuthorResponse 짱구 = new AuthorResponse(짱구_정보.getId(), 짱구_이름, 짱구_이미지_URL, 짱구_프로필_URL);
         final LinkResponse 짱구_링크 = new LinkResponse(짱구_링크공유_ID, 짱구, editingLinkRequest.getLinkUrl(),
                 editingLinkRequest.getDescription(), 링크_생성일, 링크_수정일);
 

--- a/backend/src/test/java/com/woowacourse/acceptance/test/study/GettingStudyDetailsAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/acceptance/test/study/GettingStudyDetailsAcceptanceTest.java
@@ -3,11 +3,9 @@ package com.woowacourse.acceptance.test.study;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_이름;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_이미지_URL;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_프로필_URL;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.디우_깃허브_ID;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.디우_이름;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.디우_이미지_URL;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.디우_프로필_URL;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.베루스_깃허브_ID;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.베루스_이름;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.베루스_이미지_URL;
 import static com.woowacourse.acceptance.fixture.MemberFixtures.베루스_프로필_URL;
@@ -75,7 +73,7 @@ class GettingStudyDetailsAcceptanceTest extends AcceptanceTest {
                 .body("enrollmentEndDate", is(지금.plusDays(4).toString()))
                 .body("startDate", is(지금.toString()))
                 .body("endDate", is(지금.plusDays(10).toString()))
-                .body("owner.id", is((int)디우_깃허브_ID))
+                .body("owner.id", not(empty()))
                 .body("owner.username", is(디우_이름))
                 .body("owner.imageUrl", is(디우_이미지_URL))
                 .body("owner.profileUrl", is(디우_프로필_URL))
@@ -114,7 +112,7 @@ class GettingStudyDetailsAcceptanceTest extends AcceptanceTest {
                 .body("enrollmentEndDate", is(nullValue()))
                 .body("startDate", is(지금.toString()))
                 .body("endDate", is(nullValue()))
-                .body("owner.id", is((int)베루스_깃허브_ID))
+                .body("owner.id", not(empty()))
                 .body("owner.username", is(베루스_이름))
                 .body("owner.imageUrl", is(베루스_이미지_URL))
                 .body("owner.profileUrl", is(베루스_프로필_URL))

--- a/backend/src/test/java/com/woowacourse/acceptance/test/studyroom/CommunityAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/acceptance/test/studyroom/CommunityAcceptanceTest.java
@@ -1,13 +1,5 @@
 package com.woowacourse.acceptance.test.studyroom;
 
-import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_깃허브_ID;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_이름;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_이미지_URL;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_프로필_URL;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.베루스_깃허브_ID;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.베루스_이름;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.베루스_이미지_URL;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.베루스_프로필_URL;
 import static com.woowacourse.acceptance.steps.LoginSteps.그린론이;
 import static com.woowacourse.acceptance.steps.LoginSteps.베루스가;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,6 +16,7 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.woowacourse.acceptance.AcceptanceTest;
+import com.woowacourse.moamoa.member.service.response.MemberResponse;
 import com.woowacourse.moamoa.studyroom.service.request.ArticleRequest;
 import com.woowacourse.moamoa.studyroom.service.response.ArticleResponse;
 import com.woowacourse.moamoa.studyroom.service.response.ArticleSummariesResponse;
@@ -117,9 +110,11 @@ class CommunityAcceptanceTest extends AcceptanceTest {
                 .statusCode(HttpStatus.OK.value())
                 .extract().as(ArticleResponse.class);
 
+        final MemberResponse 그린론_정보 = 그린론이().로그인하고().정보를_가져온다();
+
         final ArticleResponse expectedResponse = ArticleResponse.builder()
                 .id(articleId)
-                .author(new AuthorResponse(그린론_깃허브_ID, 그린론_이름, 그린론_이미지_URL, 그린론_프로필_URL))
+                .author(new AuthorResponse(그린론_정보.getId(), 그린론_정보.getUsername(), 그린론_정보.getImageUrl(), 그린론_정보.getProfileUrl()))
                 .title("게시글 제목")
                 .content("게시글 내용")
                 .createdDate(LocalDate.now())
@@ -231,7 +226,8 @@ class CommunityAcceptanceTest extends AcceptanceTest {
                 .extract().as(ArticleSummariesResponse.class);
 
         // assert
-        AuthorResponse 베루스 = new AuthorResponse(베루스_깃허브_ID, 베루스_이름, 베루스_이미지_URL, 베루스_프로필_URL);
+        final MemberResponse 베루스_정보 = 베루스가().로그인하고().정보를_가져온다();
+        AuthorResponse 베루스 = new AuthorResponse(베루스_정보.getId(), 베루스_정보.getUsername(), 베루스_정보.getImageUrl(), 베루스_정보.getProfileUrl());
 
         List<ArticleSummaryResponse> articles = List.of(
                 new ArticleSummaryResponse(자바_게시글4_ID, 베루스, "자바 게시글 제목4", LocalDate.now(), LocalDate.now()),
@@ -265,7 +261,8 @@ class CommunityAcceptanceTest extends AcceptanceTest {
                 .extract().as(ArticleSummariesResponse.class);
 
         // assert
-        AuthorResponse 그린론 = new AuthorResponse(그린론_깃허브_ID, 그린론_이름, 그린론_이미지_URL, 그린론_프로필_URL);
+        final MemberResponse 그린론_정보 = 그린론이().로그인하고().정보를_가져온다();
+        AuthorResponse 그린론 = new AuthorResponse(그린론_정보.getId(), 그린론_정보.getUsername(), 그린론_정보.getImageUrl(), 그린론_정보.getProfileUrl());
 
         List<ArticleSummaryResponse> articles = List.of(
                 new ArticleSummaryResponse(게시글4_ID, 그린론, "자바 게시글 제목4", LocalDate.now(), LocalDate.now()),
@@ -325,7 +322,8 @@ class CommunityAcceptanceTest extends AcceptanceTest {
                 .extract()
                 .as(ArticleResponse.class);
 
-        final AuthorResponse authorResponse = new AuthorResponse(그린론_깃허브_ID, 그린론_이름, 그린론_이미지_URL, 그린론_프로필_URL);
+        final MemberResponse 그린론_정보 = 그린론이().로그인하고().정보를_가져온다();
+        final AuthorResponse authorResponse = new AuthorResponse(그린론_정보.getId(), 그린론_정보.getUsername(), 그린론_정보.getImageUrl(), 그린론_정보.getProfileUrl());
 
         assertThat(response).isEqualTo(new ArticleResponse(스터디_ID, authorResponse, "게시글 제목 수정",
                 "게시글 내용 수정", LocalDate.now(), LocalDate.now()));

--- a/backend/src/test/java/com/woowacourse/acceptance/test/studyroom/NoticeAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/acceptance/test/studyroom/NoticeAcceptanceTest.java
@@ -1,9 +1,5 @@
 package com.woowacourse.acceptance.test.studyroom;
 
-import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_깃허브_ID;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_이름;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_이미지_URL;
-import static com.woowacourse.acceptance.fixture.MemberFixtures.그린론_프로필_URL;
 import static com.woowacourse.acceptance.steps.LoginSteps.그린론이;
 import static com.woowacourse.acceptance.steps.LoginSteps.베루스가;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,6 +16,7 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.woowacourse.acceptance.AcceptanceTest;
+import com.woowacourse.moamoa.member.service.response.MemberResponse;
 import com.woowacourse.moamoa.studyroom.service.request.ArticleRequest;
 import com.woowacourse.moamoa.studyroom.service.response.ArticleResponse;
 import com.woowacourse.moamoa.studyroom.service.response.ArticleSummariesResponse;
@@ -113,9 +110,10 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
                 .statusCode(HttpStatus.OK.value())
                 .extract().as(ArticleResponse.class);
 
+        final MemberResponse 그린론_정보 = 그린론이().로그인하고().정보를_가져온다();
         final ArticleResponse expectedResponse = ArticleResponse.builder()
                 .id(articleId)
-                .author(new AuthorResponse(그린론_깃허브_ID, 그린론_이름, 그린론_이미지_URL, 그린론_프로필_URL))
+                .author(new AuthorResponse(그린론_정보.getId(), 그린론_정보.getUsername(), 그린론_정보.getImageUrl(), 그린론_정보.getProfileUrl()))
                 .title("공지사항 제목")
                 .content("공지사항 내용")
                 .createdDate(LocalDate.now())
@@ -225,7 +223,8 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
                 .extract().as(ArticleSummariesResponse.class);
 
         // assert
-        AuthorResponse 그린론 = new AuthorResponse(그린론_깃허브_ID, 그린론_이름, 그린론_이미지_URL, 그린론_프로필_URL);
+        final MemberResponse 그린론_정보 = 그린론이().로그인하고().정보를_가져온다();
+        AuthorResponse 그린론 = new AuthorResponse(그린론_정보.getId(), 그린론_정보.getUsername(), 그린론_정보.getImageUrl(), 그린론_정보.getProfileUrl());
 
         List<ArticleSummaryResponse> articles = List.of(
                 new ArticleSummaryResponse(자바_공지글4_ID, 그린론, "자바 게시글 제목4", LocalDate.now(), LocalDate.now()),
@@ -259,7 +258,8 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
                 .extract().as(ArticleSummariesResponse.class);
 
         // assert
-        AuthorResponse 그린론 = new AuthorResponse(그린론_깃허브_ID, 그린론_이름, 그린론_이미지_URL, 그린론_프로필_URL);
+        final MemberResponse 그린론_정보 = 그린론이().로그인하고().정보를_가져온다();
+        AuthorResponse 그린론 = new AuthorResponse(그린론_정보.getId(), 그린론_정보.getUsername(), 그린론_정보.getImageUrl(), 그린론_정보.getProfileUrl());
 
         List<ArticleSummaryResponse> articles = List.of(
                 new ArticleSummaryResponse(공지글4_ID, 그린론, "자바 게시글 제목4", LocalDate.now(), LocalDate.now()),
@@ -319,7 +319,8 @@ public class NoticeAcceptanceTest extends AcceptanceTest {
                 .extract()
                 .as(ArticleResponse.class);
 
-        final AuthorResponse authorResponse = new AuthorResponse(그린론_깃허브_ID, 그린론_이름, 그린론_이미지_URL, 그린론_프로필_URL);
+        final MemberResponse 그린론_정보 = 그린론이().로그인하고().정보를_가져온다();
+        final AuthorResponse authorResponse = new AuthorResponse(그린론_정보.getId(), 그린론_정보.getUsername(), 그린론_정보.getImageUrl(), 그린론_정보.getProfileUrl());
 
         assertThat(response).isEqualTo(new ArticleResponse(스터디_ID, authorResponse, "게시글 제목 수정",
                 "게시글 내용 수정", LocalDate.now(), LocalDate.now()));

--- a/backend/src/test/java/com/woowacourse/moamoa/fixtures/MemberFixtures.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/fixtures/MemberFixtures.java
@@ -1,7 +1,6 @@
 package com.woowacourse.moamoa.fixtures;
 
 import com.woowacourse.moamoa.member.domain.Member;
-import com.woowacourse.moamoa.member.query.data.MemberData;
 
 public class MemberFixtures {
 
@@ -11,7 +10,6 @@ public class MemberFixtures {
     public static final String 짱구_유저네임 = "jjanggu";
     public static final String 짱구_이미지 = "https://jjanggu.png";
     public static final String 짱구_프로필 = "https://jjanggu.com";
-    public static final MemberData 짱구_응답 = new MemberData(짱구_깃허브_아이디, 짱구_유저네임, 짱구_이미지, 짱구_프로필);
 
     /* 그린론 */
     public static final Long 그린론_아이디 = 2L;
@@ -19,7 +17,6 @@ public class MemberFixtures {
     public static final String 그린론_유저네임 = "greenlawn";
     public static final String 그린론_이미지 = "https://greenlawn.png";
     public static final String 그린론_프로필 = "https://greenlawn.com";
-    public static final MemberData 그린론_응답 = new MemberData(그린론_깃허브_아이디, 그린론_유저네임, 그린론_이미지, 그린론_프로필);
 
     /* 디우 */
     public static final Long 디우_아이디 = 3L;
@@ -27,7 +24,6 @@ public class MemberFixtures {
     public static final String 디우_유저네임 = "dwoo";
     public static final String 디우_이미지 = "https://dwoo.png";
     public static final String 디우_프로필 = "https://dwoo.com";
-    public static final MemberData 디우_응답 = new MemberData(디우_깃허브_아이디, 디우_유저네임, 디우_이미지, 디우_프로필);
 
     /* 베루스 */
     public static final Long 베루스_아이디 = 4L;
@@ -35,21 +31,18 @@ public class MemberFixtures {
     public static final String 베루스_유저네임 = "verus";
     public static final String 베루스_이미지 = "https://verus.png";
     public static final String 베루스_프로필 = "https://verus.com";
-    public static final MemberData 베루스_응답 = new MemberData(베루스_깃허브_아이디, 베루스_유저네임, 베루스_이미지, 베루스_프로필);
 
     /* 병민 */
     public static final Long 병민_깃허브_아이디 = 5L;
     public static final String 병민_유저네임 = "airman";
     public static final String 병민_이미지 = "https://airman.png";
     public static final String 병민_프로필 = "https://airman.com";
-    public static final MemberData 병민_응답 = new MemberData(병민_깃허브_아이디, 병민_유저네임, 병민_이미지, 병민_프로필);
 
     /* 태태 */
     public static final Long 태태_깃허브_아이디 = 6L;
     public static final String 태태_유저네임 = "nannoo";
     public static final String 태태_이미지 = "https://nannoo.png";
     public static final String 태태_프로필 = "https://nannoo.com";
-    public static final MemberData 태태_응답 = new MemberData(태태_깃허브_아이디, 태태_유저네임, 태태_이미지, 태태_프로필);
 
     public static Member 짱구() {
         return new Member(짱구_깃허브_아이디, 짱구_유저네임, 짱구_이미지, 짱구_프로필);

--- a/backend/src/test/java/com/woowacourse/moamoa/referenceroom/controller/SearchingReferenceRoomControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/referenceroom/controller/SearchingReferenceRoomControllerTest.java
@@ -1,14 +1,10 @@
 package com.woowacourse.moamoa.referenceroom.controller;
 
 import static com.woowacourse.moamoa.fixtures.MemberFixtures.그린론;
-import static com.woowacourse.moamoa.fixtures.MemberFixtures.그린론_응답;
 import static com.woowacourse.moamoa.fixtures.MemberFixtures.디우;
-import static com.woowacourse.moamoa.fixtures.MemberFixtures.디우_응답;
 import static com.woowacourse.moamoa.fixtures.MemberFixtures.베루스;
-import static com.woowacourse.moamoa.fixtures.MemberFixtures.베루스_응답;
 import static com.woowacourse.moamoa.fixtures.MemberFixtures.병민;
 import static com.woowacourse.moamoa.fixtures.MemberFixtures.짱구;
-import static com.woowacourse.moamoa.fixtures.MemberFixtures.짱구_응답;
 import static com.woowacourse.moamoa.fixtures.StudyFixtures.자바_스터디_신청서;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -18,6 +14,7 @@ import com.woowacourse.moamoa.common.RepositoryTest;
 import com.woowacourse.moamoa.common.utils.DateTimeSystem;
 import com.woowacourse.moamoa.member.domain.Member;
 import com.woowacourse.moamoa.member.domain.repository.MemberRepository;
+import com.woowacourse.moamoa.member.query.data.MemberData;
 import com.woowacourse.moamoa.referenceroom.domain.Link;
 import com.woowacourse.moamoa.referenceroom.domain.repository.LinkRepository;
 import com.woowacourse.moamoa.referenceroom.query.LinkDao;
@@ -115,6 +112,15 @@ class SearchingReferenceRoomControllerTest {
 
         entityManager.flush();
         entityManager.clear();
+
+        final MemberData 짱구_응답 = new MemberData(짱구.getId(), 짱구.getUsername(), 짱구.getImageUrl(),
+                짱구.getProfileUrl());
+        final MemberData 그린론_응답 = new MemberData(그린론.getId(), 그린론.getUsername(), 그린론.getImageUrl(),
+                그린론.getProfileUrl());
+        final MemberData 디우_응답 = new MemberData(디우.getId(), 디우.getUsername(), 디우.getImageUrl(),
+                디우.getProfileUrl());
+        final MemberData 베루스_응답 = new MemberData(베루스.getId(), 베루스.getUsername(), 베루스.getImageUrl(),
+                베루스.getProfileUrl());
 
         final LinkResponse 링크1 = new LinkResponse(
                 new LinkData(link1.getId(), 짱구_응답, link1.getLinkUrl(), link1.getDescription(),

--- a/backend/src/test/java/com/woowacourse/moamoa/referenceroom/query/LinkDaoTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/referenceroom/query/LinkDaoTest.java
@@ -1,5 +1,9 @@
 package com.woowacourse.moamoa.referenceroom.query;
 
+import static com.woowacourse.moamoa.fixtures.MemberFixtures.그린론;
+import static com.woowacourse.moamoa.fixtures.MemberFixtures.디우;
+import static com.woowacourse.moamoa.fixtures.MemberFixtures.베루스;
+import static com.woowacourse.moamoa.fixtures.MemberFixtures.짱구;
 import static com.woowacourse.moamoa.fixtures.StudyFixtures.자바_스터디_신청서;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -32,11 +36,6 @@ import org.springframework.data.domain.Slice;
 @RepositoryTest
 class LinkDaoTest {
 
-    private static final MemberData JJANGGU = new MemberData(1L, "jjanggu", "https://image", "github.com");
-    private static final MemberData GREENLAWN = new MemberData(2L, "greenlawn", "https://image", "github.com");
-    private static final MemberData DWOO = new MemberData(3L, "dwoo", "https://image", "github.com");
-    private static final MemberData VERUS = new MemberData(4L, "verus", "https://image", "github.com");
-
     @Autowired
     private MemberRepository memberRepository;
 
@@ -59,10 +58,10 @@ class LinkDaoTest {
     @BeforeEach
     void setUp() {
         // 사용자 추가
-        final Member jjanggu = memberRepository.save(toMember(JJANGGU));
-        final Member greenlawn = memberRepository.save(toMember(GREENLAWN));
-        final Member dwoo = memberRepository.save(toMember(DWOO));
-        final Member verus = memberRepository.save(toMember(VERUS));
+        final Member 짱구 = memberRepository.save(짱구());
+        final Member 그린론 = memberRepository.save(그린론());
+        final Member 디우 = memberRepository.save(디우());
+        final Member 베루스 = memberRepository.save(베루스());
 
         // 스터디 생성
         StudyService createStudyService = new StudyService(studyRepository, memberRepository, new DateTimeSystem());
@@ -70,12 +69,12 @@ class LinkDaoTest {
         final LocalDate startDate = LocalDate.now();
         StudyRequest javaStudyRequest = 자바_스터디_신청서(startDate);
 
-        javaStudy = createStudyService.createStudy(jjanggu.getId(), javaStudyRequest);
+        javaStudy = createStudyService.createStudy(짱구.getId(), javaStudyRequest);
 
         StudyParticipantService participantService = new StudyParticipantService(memberRepository, studyRepository);
-        participantService.participateStudy(greenlawn.getId(), javaStudy.getId());
-        participantService.participateStudy(dwoo.getId(), javaStudy.getId());
-        participantService.participateStudy(verus.getId(), javaStudy.getId());
+        participantService.participateStudy(그린론 .getId(), javaStudy.getId());
+        participantService.participateStudy(디우.getId(), javaStudy.getId());
+        participantService.participateStudy(베루스.getId(), javaStudy.getId());
 
         // 링크 공유 추가
         final ReferenceRoomService linkService = new ReferenceRoomService(memberRepository, studyRepository, linkRepository);
@@ -85,24 +84,25 @@ class LinkDaoTest {
         final CreatingLinkRequest request3 = new CreatingLinkRequest("https://github.com/tco0427", "디우 링크.");
         final CreatingLinkRequest request4 = new CreatingLinkRequest("https://github.com/wilgur513", "베루스 링크.");
 
-        final Link link1 = linkService.createLink(jjanggu.getId(), javaStudy.getId(), request1);
-        final Link link2 = linkService.createLink(greenlawn.getId(), javaStudy.getId(), request2);
-        final Link link3 = linkService.createLink(dwoo.getId(), javaStudy.getId(), request3);
-        final Link link4 = linkService.createLink(verus.getId(), javaStudy.getId(), request4);
+        final Link link1 = linkService.createLink(짱구.getId(), javaStudy.getId(), request1);
+        final Link link2 = linkService.createLink(그린론 .getId(), javaStudy.getId(), request2);
+        final Link link3 = linkService.createLink(디우.getId(), javaStudy.getId(), request3);
+        final Link link4 = linkService.createLink(베루스.getId(), javaStudy.getId(), request4);
 
         entityManager.flush();
         entityManager.clear();
 
-        final LinkData 링크1 = new LinkData(link1.getId(), JJANGGU, link1.getLinkUrl(), link1.getDescription(), link1.getCreatedDate().toLocalDate(), link1.getLastModifiedDate().toLocalDate());
-        final LinkData 링크2 = new LinkData(link2.getId(), GREENLAWN, link2.getLinkUrl(), link2.getDescription(), link2.getCreatedDate().toLocalDate(), link2.getLastModifiedDate().toLocalDate());
-        final LinkData 링크3 = new LinkData(link3.getId(), DWOO, link3.getLinkUrl(), link3.getDescription(), link3.getCreatedDate().toLocalDate(), link3.getLastModifiedDate().toLocalDate());
-        final LinkData 링크4 = new LinkData(link4.getId(), VERUS, link4.getLinkUrl(), link4.getDescription(), link4.getCreatedDate().toLocalDate(), link4.getLastModifiedDate().toLocalDate());
+        final MemberData 짱구_응답 = toMemberData(짱구);
+        final MemberData 그린론_응답 = toMemberData(그린론);
+        final MemberData 디우_응답 = toMemberData(디우);
+        final MemberData 베루스_응답 = toMemberData(베루스);
+
+        final LinkData 링크1 = new LinkData(link1.getId(), 짱구_응답, link1.getLinkUrl(), link1.getDescription(), link1.getCreatedDate().toLocalDate(), link1.getLastModifiedDate().toLocalDate());
+        final LinkData 링크2 = new LinkData(link2.getId(), 그린론_응답, link2.getLinkUrl(), link2.getDescription(), link2.getCreatedDate().toLocalDate(), link2.getLastModifiedDate().toLocalDate());
+        final LinkData 링크3 = new LinkData(link3.getId(), 디우_응답, link3.getLinkUrl(), link3.getDescription(), link3.getCreatedDate().toLocalDate(), link3.getLastModifiedDate().toLocalDate());
+        final LinkData 링크4 = new LinkData(link4.getId(), 베루스_응답, link4.getLinkUrl(), link4.getDescription(), link4.getCreatedDate().toLocalDate(), link4.getLastModifiedDate().toLocalDate());
 
         linkData = List.of(링크1, 링크2, 링크3, 링크4);
-    }
-
-    private Member toMember(final MemberData data) {
-        return new Member(data.getId(), data.getUsername(), data.getImageUrl(), data.getProfileUrl());
     }
 
     @DisplayName("스터디 ID로 링크 공유글을 조회한다.")
@@ -115,5 +115,9 @@ class LinkDaoTest {
                 () -> assertThat(links.getContent())
                         .containsExactlyInAnyOrderElementsOf(linkData)
         );
+    }
+
+    private MemberData toMemberData(final Member member) {
+        return new MemberData(member.getId(), member.getUsername(), member.getImageUrl(), member.getProfileUrl());
     }
 }

--- a/backend/src/test/java/com/woowacourse/moamoa/review/controller/SearchingReviewControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/review/controller/SearchingReviewControllerTest.java
@@ -1,13 +1,9 @@
 package com.woowacourse.moamoa.review.controller;
 
 import static com.woowacourse.moamoa.fixtures.MemberFixtures.그린론;
-import static com.woowacourse.moamoa.fixtures.MemberFixtures.그린론_응답;
 import static com.woowacourse.moamoa.fixtures.MemberFixtures.디우;
-import static com.woowacourse.moamoa.fixtures.MemberFixtures.디우_응답;
 import static com.woowacourse.moamoa.fixtures.MemberFixtures.베루스;
-import static com.woowacourse.moamoa.fixtures.MemberFixtures.베루스_응답;
 import static com.woowacourse.moamoa.fixtures.MemberFixtures.짱구;
-import static com.woowacourse.moamoa.fixtures.MemberFixtures.짱구_응답;
 import static com.woowacourse.moamoa.fixtures.StudyFixtures.리액트_스터디_신청서;
 import static com.woowacourse.moamoa.fixtures.StudyFixtures.자바_스터디_신청서;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,6 +12,7 @@ import com.woowacourse.moamoa.common.RepositoryTest;
 import com.woowacourse.moamoa.common.utils.DateTimeSystem;
 import com.woowacourse.moamoa.member.domain.Member;
 import com.woowacourse.moamoa.member.domain.repository.MemberRepository;
+import com.woowacourse.moamoa.member.query.data.MemberData;
 import com.woowacourse.moamoa.review.domain.repository.ReviewRepository;
 import com.woowacourse.moamoa.review.query.ReviewDao;
 import com.woowacourse.moamoa.review.service.ReviewService;
@@ -64,15 +61,20 @@ class SearchingReviewControllerTest {
 
     private List<ReviewResponse> javaReviews;
 
+    private Member 짱구;
+    private Member 그린론;
+    private Member 디우;
+    private Member 베루스;
+
     @BeforeEach
     void setUp() {
         sut = new SearchingReviewController(new SearchingReviewService(reviewDao));
 
         // 사용자 추가
-        final Member jjanggu = memberRepository.save(짱구());
-        final Member greenlawn = memberRepository.save(그린론());
-        final Member dwoo = memberRepository.save(디우());
-        final Member verus = memberRepository.save(베루스());
+        짱구 = memberRepository.save(짱구());
+        그린론 = memberRepository.save(그린론());
+        디우 = memberRepository.save(디우());
+        베루스 = memberRepository.save(베루스());
 
         // 스터디 생성
         StudyService studyService = new StudyService(studyRepository, memberRepository, new DateTimeSystem());
@@ -81,26 +83,35 @@ class SearchingReviewControllerTest {
         StudyRequest javaStudyRequest = 자바_스터디_신청서(startDate);
         StudyRequest reactStudyRequest = 리액트_스터디_신청서(startDate);
 
-        javaStudy = studyService.createStudy(jjanggu.getId(), javaStudyRequest);
-        final Study reactStudy = studyService.createStudy(jjanggu.getId(), reactStudyRequest);
+        javaStudy = studyService.createStudy(짱구.getId(), javaStudyRequest);
+        final Study reactStudy = studyService.createStudy(짱구.getId(), reactStudyRequest);
 
         StudyParticipantService participantService = new StudyParticipantService(memberRepository, studyRepository);
-        participantService.participateStudy(greenlawn.getId(), javaStudy.getId());
-        participantService.participateStudy(dwoo.getId(), javaStudy.getId());
-        participantService.participateStudy(verus.getId(), javaStudy.getId());
+        participantService.participateStudy(그린론.getId(), javaStudy.getId());
+        participantService.participateStudy(디우.getId(), javaStudy.getId());
+        participantService.participateStudy(베루스.getId(), javaStudy.getId());
 
         // 리뷰 추가
         ReviewService reviewService = new ReviewService(reviewRepository, memberRepository, studyRepository);
 
         final Long javaReviewId1 = reviewService
-                .writeReview(jjanggu.getId(), javaStudy.getId(), new WriteReviewRequest("리뷰 내용1"));
+                .writeReview(짱구.getId(), javaStudy.getId(), new WriteReviewRequest("리뷰 내용1"));
         final Long javaReviewId2 = reviewService
-                .writeReview(greenlawn.getId(), javaStudy.getId(), new WriteReviewRequest("리뷰 내용2"));
+                .writeReview(그린론.getId(), javaStudy.getId(), new WriteReviewRequest("리뷰 내용2"));
         final Long javaReviewId3 = reviewService
-                .writeReview(dwoo.getId(), javaStudy.getId(), new WriteReviewRequest("리뷰 내용3"));
+                .writeReview(디우.getId(), javaStudy.getId(), new WriteReviewRequest("리뷰 내용3"));
         final Long javaReviewId4 = reviewService
-                .writeReview(verus.getId(), javaStudy.getId(), new WriteReviewRequest("리뷰 내용4"));
-        reviewService.writeReview(jjanggu.getId(), reactStudy.getId(), new WriteReviewRequest("리뷰 내용5"));
+                .writeReview(베루스.getId(), javaStudy.getId(), new WriteReviewRequest("리뷰 내용4"));
+        reviewService.writeReview(짱구.getId(), reactStudy.getId(), new WriteReviewRequest("리뷰 내용5"));
+
+        final MemberData 짱구_응답 = new MemberData(짱구.getId(), 짱구.getUsername(), 짱구.getImageUrl(),
+                짱구.getProfileUrl());
+        final MemberData 그린론_응답 = new MemberData(그린론.getId(), 그린론.getUsername(), 그린론.getImageUrl(),
+                그린론.getProfileUrl());
+        final MemberData 디우_응답 = new MemberData(디우.getId(), 디우.getUsername(), 디우.getImageUrl(),
+                디우.getProfileUrl());
+        final MemberData 베루스_응답 = new MemberData(베루스.getId(), 베루스.getUsername(), 베루스.getImageUrl(),
+                베루스.getProfileUrl());
 
         final ReviewResponse 리뷰_내용1 = new ReviewResponse(javaReviewId1, new WriterResponse(짱구_응답), LocalDate.now(),
                 LocalDate.now(), "리뷰 내용1");

--- a/backend/src/test/java/com/woowacourse/moamoa/review/query/ReviewDaoTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/review/query/ReviewDaoTest.java
@@ -105,21 +105,21 @@ class ReviewDaoTest {
         entityManager.flush();
 
         javaReviews = List.of(
-                new ReviewData(forthJavaReview.getId(), new MemberData(짱구.getGithubId(), 짱구.getUsername(), 짱구.getImageUrl(), 짱구.getProfileUrl()),
+                new ReviewData(forthJavaReview.getId(), new MemberData(짱구.getId(), 짱구.getUsername(), 짱구.getImageUrl(), 짱구.getProfileUrl()),
                         firstJavaReview.getCreatedDate().toLocalDate(), firstJavaReview.getLastModifiedDate().toLocalDate(), 자바_리뷰1_내용),
-                new ReviewData(thirdJavaReview.getId(), new MemberData(그린론.getGithubId(), 그린론.getUsername(), 그린론.getImageUrl(), 그린론.getProfileUrl()),
+                new ReviewData(thirdJavaReview.getId(), new MemberData(그린론.getId(), 그린론.getUsername(), 그린론.getImageUrl(), 그린론.getProfileUrl()),
                         secondJavaReview.getCreatedDate().toLocalDate(), secondJavaReview.getLastModifiedDate().toLocalDate(), 자바_리뷰2_내용),
-                new ReviewData(secondJavaReview.getId(), new MemberData(디우.getGithubId(), 디우.getUsername(), 디우.getImageUrl(), 디우.getProfileUrl()),
+                new ReviewData(secondJavaReview.getId(), new MemberData(디우.getId(), 디우.getUsername(), 디우.getImageUrl(), 디우.getProfileUrl()),
                         thirdJavaReview.getCreatedDate().toLocalDate(), thirdJavaReview.getLastModifiedDate().toLocalDate(), 자바_리뷰3_내용),
-                new ReviewData(firstJavaReview.getId(), new MemberData(베루스.getGithubId(), 베루스.getUsername(), 베루스.getImageUrl(), 베루스.getProfileUrl()),
+                new ReviewData(firstJavaReview.getId(), new MemberData(베루스.getId(), 베루스.getUsername(), 베루스.getImageUrl(), 베루스.getProfileUrl()),
                         forthJavaReview.getCreatedDate().toLocalDate(), forthJavaReview.getLastModifiedDate().toLocalDate(), 자바_리뷰4_내용)
         );
         reactReviews = List.of(
-                new ReviewData(firstReactReview.getId(), new MemberData(짱구.getGithubId(), 짱구.getUsername(), 짱구.getImageUrl(), 짱구.getProfileUrl()),
+                new ReviewData(firstReactReview.getId(), new MemberData(짱구.getId(), 짱구.getUsername(), 짱구.getImageUrl(), 짱구.getProfileUrl()),
                         firstReactReview.getCreatedDate().toLocalDate(), firstReactReview.getLastModifiedDate().toLocalDate(), 리액트_리뷰1_내용),
-                new ReviewData(secondReactReview.getId(), new MemberData(그린론.getGithubId(), 그린론.getUsername(), 그린론.getImageUrl(), 그린론.getProfileUrl()),
+                new ReviewData(secondReactReview.getId(), new MemberData(그린론.getId(), 그린론.getUsername(), 그린론.getImageUrl(), 그린론.getProfileUrl()),
                         secondReactReview.getCreatedDate().toLocalDate(), secondReactReview.getLastModifiedDate().toLocalDate(), 리액트_리뷰2_내용),
-                new ReviewData(thirdReactReview.getId(), new MemberData(디우.getGithubId(), 디우.getUsername(), 디우.getImageUrl(), 디우.getProfileUrl()),
+                new ReviewData(thirdReactReview.getId(), new MemberData(디우.getId(), 디우.getUsername(), 디우.getImageUrl(), 디우.getProfileUrl()),
                         thirdReactReview.getCreatedDate().toLocalDate(), thirdReactReview.getLastModifiedDate().toLocalDate(), 리액트_리뷰3_내용)
         );
     }

--- a/backend/src/test/java/com/woowacourse/moamoa/study/controller/SearchingStudyControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/study/controller/SearchingStudyControllerTest.java
@@ -245,14 +245,14 @@ class SearchingStudyControllerTest {
                 .status("RECRUITMENT_START").description("그린론의 우당탕탕 자바 스터디입니다.").createdDate(LocalDate.now())
                 // Study Participant
                 .currentMemberCount(3).maxMemberCount(10)
-                .owner(new OwnerData(jjanggu.getGithubId(), "jjanggu", "https://image", "github.com", LocalDate.now(), 5))
+                .owner(new OwnerData(jjanggu.getId(), "jjanggu", "https://image", "github.com", LocalDate.now(), 5))
                 // Study Period
                 .startDate(LocalDate.now())
                 .build();
 
         final List<Tuple> expectParticipants = List.of(
-                tuple(dwoo.getGithubId(), "dwoo", "https://image", "github.com"),
-                tuple(verus.getGithubId(), "verus", "https://image", "github.com")
+                tuple(dwoo.getId(), "dwoo", "https://image", "github.com"),
+                tuple(verus.getId(), "verus", "https://image", "github.com")
         );
 
         final List<Tuple> expectAttachedTags = List.of(
@@ -280,7 +280,7 @@ class SearchingStudyControllerTest {
                 .status("RECRUITMENT_START").description("디우의 뤼액트 스터디입니다.").createdDate(LocalDate.now())
                 // Study Participant
                 .currentMemberCount(4).maxMemberCount(5)
-                .owner(new OwnerData(dwoo.getGithubId(), "dwoo", "https://image", "github.com", LocalDate.now(),3))
+                .owner(new OwnerData(dwoo.getId(), "dwoo", "https://image", "github.com", LocalDate.now(),3))
                 // Study Period
                 .enrollmentEndDate(LocalDate.now())
                 .startDate(LocalDate.now())
@@ -288,9 +288,9 @@ class SearchingStudyControllerTest {
                 .build();
 
         final List<Tuple> expectParticipants = List.of(
-                tuple(jjanggu.getGithubId(), "jjanggu", "https://image", "github.com"),
-                tuple(greenlawn.getGithubId(), "greenlawn", "https://image", "github.com"),
-                tuple(verus.getGithubId(), "verus", "https://image", "github.com")
+                tuple(jjanggu.getId(), "jjanggu", "https://image", "github.com"),
+                tuple(greenlawn.getId(), "greenlawn", "https://image", "github.com"),
+                tuple(verus.getId(), "verus", "https://image", "github.com")
         );
 
         final List<Tuple> expectAttachedTags = List.of(
@@ -318,7 +318,7 @@ class SearchingStudyControllerTest {
                 .status("RECRUITMENT_START").description("Linux를 공부하자의 베루스입니다.").createdDate(LocalDate.now())
                 // Study Participant
                 .currentMemberCount(1)
-                .owner(new OwnerData(verus.getGithubId(), "verus", "https://image", "github.com", LocalDate.now(), 4))
+                .owner(new OwnerData(verus.getId(), "verus", "https://image", "github.com", LocalDate.now(), 4))
                 // Study Period
                 .startDate(LocalDate.now())
                 .enrollmentEndDate(LocalDate.now())
@@ -350,10 +350,10 @@ class SearchingStudyControllerTest {
         assertThat(responseBody.getMembers())
                 .filteredOn(member -> member.getParticipationDate() != null)
                 .hasSize(2)
-                .extracting("githubId", "username", "imageUrl", "profileUrl", "numberOfStudy")
+                .extracting("id", "username", "imageUrl", "profileUrl", "numberOfStudy")
                 .containsExactlyInAnyOrder(
-                        tuple(dwoo.getGithubId(), dwoo.getUsername(), dwoo.getImageUrl(), dwoo.getProfileUrl(), 3),
-                        tuple(verus.getGithubId(), verus.getUsername(), verus.getImageUrl(), verus.getProfileUrl(), 4)
+                        tuple(dwoo.getId(), dwoo.getUsername(), dwoo.getImageUrl(), dwoo.getProfileUrl(), 3),
+                        tuple(verus.getId(), verus.getUsername(), verus.getImageUrl(), verus.getProfileUrl(), 4)
                 );
     }
 
@@ -375,7 +375,7 @@ class SearchingStudyControllerTest {
         assertThat(actual.getOwner()).isEqualTo(expect.getOwner());
         assertThat(actual.getMembers())
                 .hasSize(expectParticipants.size())
-                .extracting("githubId", "username", "imageUrl", "profileUrl")
+                .extracting("id", "username", "imageUrl", "profileUrl")
                 .containsExactlyInAnyOrderElementsOf(expectParticipants);
     }
 

--- a/backend/src/test/java/com/woowacourse/moamoa/study/query/StudyDetailsDaoTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/study/query/StudyDetailsDaoTest.java
@@ -86,7 +86,7 @@ class StudyDetailsDaoTest {
                 .description(알고리즘_스터디.getContent().getDescription()).createdDate(actual.getCreatedDate())
                 // Study Participants
                 .currentMemberCount(알고리즘_스터디.getParticipants().getSize())
-                .owner(new OwnerData(베루스.getGithubId(), 베루스.getUsername(), 베루스.getImageUrl(), 베루스.getProfileUrl(), LocalDate.now(), 5))
+                .owner(new OwnerData(베루스.getId(), 베루스.getUsername(), 베루스.getImageUrl(), 베루스.getProfileUrl(), LocalDate.now(), 5))
                 // Study Period
                 .startDate(알고리즘_스터디.getStudyPlanner().getStartDate())
                 .build();
@@ -108,7 +108,7 @@ class StudyDetailsDaoTest {
                 .status(리눅스_스터디.getRecruitPlanner().getRecruitStatus().toString()).description(리눅스_스터디.getContent().getDescription()).createdDate(actual.getCreatedDate())
                 // Study Participant
                 .currentMemberCount(리눅스_스터디.getParticipants().getSize())
-                .owner(new OwnerData(베루스.getGithubId(), 베루스.getUsername(), 베루스.getImageUrl(), 베루스.getProfileUrl(), LocalDate.now(), 5))
+                .owner(new OwnerData(베루스.getId(), 베루스.getUsername(), 베루스.getImageUrl(), 베루스.getProfileUrl(), LocalDate.now(), 5))
                 // Study Period
                 .startDate(리눅스_스터디.getStudyPlanner().getStartDate())
                 .enrollmentEndDate(리눅스_스터디.getRecruitPlanner().getEnrollmentEndDate())

--- a/backend/src/test/java/com/woowacourse/moamoa/studyroom/controller/GettingArticleControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/studyroom/controller/GettingArticleControllerTest.java
@@ -79,7 +79,7 @@ class GettingArticleControllerTest {
 
         //assert
         final AuthorResponse expectedAuthorResponse = new AuthorResponse(
-                member.getGithubId(), member.getUsername(), member.getImageUrl(), member.getProfileUrl()
+                member.getId(), member.getUsername(), member.getImageUrl(), member.getProfileUrl()
         );
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEqualTo(

--- a/backend/src/test/java/com/woowacourse/moamoa/studyroom/controller/GettingCommunityArticleSummariesControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/studyroom/controller/GettingCommunityArticleSummariesControllerTest.java
@@ -92,7 +92,7 @@ class GettingCommunityArticleSummariesControllerTest {
                 COMMUNITY, PageRequest.of(0, 3));
 
         // assert
-        AuthorResponse author = new AuthorResponse(1L, "그린론", "http://image", "http://profile");
+        AuthorResponse author = new AuthorResponse(그린론.getId(), "그린론", "http://image", "http://profile");
 
         List<ArticleSummaryResponse> articles = List.of(
                 new ArticleSummaryResponse(article5.getId(), author, "제목5", LocalDate.now(), LocalDate.now()),


### PR DESCRIPTION
## 요약

memberId 를 응답으로 내려주도록 수정

## 세부사항

`ArgumentResolver` 는 제거하였지만, 여전히 몇몇 API 에서 githubId 를 응답으로 내려주고 있습니다.
해당 부분을 모두 통일성 있게 memberId로 수정을 진행해야 합니다.

- [x] : Article 조회시 memberId 사용하도록 수정
- [x] : Member 조회시 memberId 사용하도록 수정
- [x] : Link 조회시 memberId 사용하도록 수정
- [x] : Review 조회시 memberId 사용하도록 수정

close #359 
