### PR TITLE
[FE] fix: 스터디 칩이 포지션이 유지되지 않는 버그 수정

### DIFF
--- a/frontend/src/pages/main-page/components/study-card/StudyCard.tsx
+++ b/frontend/src/pages/main-page/components/study-card/StudyCard.tsx
@@ -25,7 +25,7 @@ export type StudyCardProps = {
 const StudyCard: React.FC<StudyCardProps> = ({ thumbnailUrl, thumbnailAlt, title, excerpt, tags, isOpen }) => {
   return (
     <Self>
-      <Card custom={{ width: '280px' }}>
+      <Card>
         <CardImage alt={thumbnailAlt} src={thumbnailUrl} />
         <div>
           <Card.Heading custom={{ marginBottom: '8px' }}>{title}</Card.Heading>


### PR DESCRIPTION


<!-- title: "[BE|FE] issue00: 제목" -->
## 요약
- 스터디 카드 너비가 고정되어 있었음

