### PR TITLE
[BE] issue464: 비관적락 사용으로 인한 데드락 상황 방지하기

### DIFF
--- a/backend/src/main/java/com/woowacourse/moamoa/study/domain/repository/StudyRepository.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/domain/repository/StudyRepository.java
@@ -4,8 +4,10 @@ import com.woowacourse.moamoa.study.domain.Study;
 import java.util.List;
 import java.util.Optional;
 import javax.persistence.LockModeType;
+import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 public interface StudyRepository {
@@ -15,6 +17,7 @@ public interface StudyRepository {
     Optional<Study> findById(Long id);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "1000")})
     @Query("select s from Study s where s.id = :id")
     Optional<Study> findByIdUpdateFor(@Param("id") Long id);
 


### PR DESCRIPTION
## 요약

비관적 락 사용으로 인한 데드락 방지하기

## 세부사항

현재 비관적 락을 사용하고 있지만 발생 가능한 데드락에 대한 대처가 없는 상황입니다.

**Q. 비관적 락을 사용하여 발생가능한 데드락에 대한 대처가 되어 있나??**

앞서 Spring Data JPA 를 통해서 정의한 `findByUpdateFor()` 을 보면 `@Lock(LockModeType.PESSIMISTIC_WIRTE)` 로 건 것을 확인할 수 있다. 우리는 동시성 제어한 필요한 곳에서 스터디를 조회할 때 해당 메소드를 활용해주고 있는데, `@Lock(LockModeType.PESSIMISTIC_WIRTE)` 의 설명을 살펴보면 "동시 업데이트 트랜잭션 중 데드락 또는 실패 가능성이 높다." 라고 데드락 발생 가능성에 대해서 경고하고 있는 것을 확인할 수 있습니다.

<img width="652" alt="스크린샷 2022-10-30 19 12 23" src="https://user-images.githubusercontent.com/57028386/198874332-f45237fa-4a3e-43b2-8683-d96d6a7b0554.png">

예를 들면 다음과 같은 상황이 될 수 있겠습니다.

```
쓰레드 1 : A 정보를 구하고 잠금
쓰레드 2 : B 정보를 구하고 잠금
쓰레드 1 : B 정보를 구하려고 하지만 잠겨있음
쓰레드 2 : A 정보를 구하려고 하지만 잠겨있음
```

이런 교착 상태를 해결하기 위한 방법으로는 락을 잡고 있는 최대 시간을 지정하는 방법이 있습니다. (잠금 시간 초과 설정, Setting Lock Timeout)

(이렇게 timeout 값을 설정해주지 않으면 어떤 문제가 있어 트랜잭션이 계속 커넥션을 잡고 있는 문제도 발생할 수 있습니다.)

`@QueryHints` 와 `@QueryHint` 어노테이션을 통해서 간단하게 지정할 수 있으며 value 속성의 단위는 밀리세컨드입니다.

3000ms 에 대한 것은 이전에 HikariCP 설정 중 1초인 경우에 저희가 원하는 vUser 50명에서 Faile 이 발생하던 것을 근거로 하고 있습니다.
<img width="1026" alt="스크린샷 2022-10-19 13 51 51" src="https://user-images.githubusercontent.com/57028386/200116405-1e570cdc-b5fe-4922-8c43-427d82cdc88b.png">

<img width="698" alt="스크린샷 2022-11-05 19 53 49" src="https://user-images.githubusercontent.com/57028386/200116423-1c4f2b16-3760-41f9-83e0-960f143789ca.png">


close #464 
