### PR TITLE
[BE] issue467: 스터디 목록 조회 커서 기반 페이징

### DIFF
--- a/backend/src/main/java/com/woowacourse/moamoa/study/controller/SearchingStudyController.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/controller/SearchingStudyController.java
@@ -4,10 +4,8 @@ import com.woowacourse.moamoa.study.query.SearchingTags;
 import com.woowacourse.moamoa.study.service.SearchingStudyService;
 import com.woowacourse.moamoa.study.service.response.StudiesResponse;
 import com.woowacourse.moamoa.study.service.response.StudyDetailResponse;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,10 +23,11 @@ public class SearchingStudyController {
     @GetMapping
     public ResponseEntity<StudiesResponse> getStudies(
             @RequestParam(required = false) final Long id,
-            @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") @RequestParam(required = false) final LocalDateTime createdAt,
+            @RequestParam(required = false, defaultValue = "") final String createdDate,
             @RequestParam(required = false, defaultValue = "5") final int size
     ) {
-        final StudiesResponse studiesResponse = searchingStudyService.getStudies("", SearchingTags.emptyTags(), id, createdAt, size);
+        final StudiesResponse studiesResponse = searchingStudyService.getStudies("", SearchingTags.emptyTags(), id,
+                createdDate, size);
         return ResponseEntity.ok().body(studiesResponse);
     }
 
@@ -39,11 +38,12 @@ public class SearchingStudyController {
             @RequestParam(required = false, name = "area", defaultValue = "") final List<Long> areas,
             @RequestParam(required = false, name = "subject", defaultValue = "") final List<Long> tags,
             @RequestParam(required = false) final Long id,
-            @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") @RequestParam(required = false) final LocalDateTime createdAt,
+            @RequestParam(required = false, defaultValue = "") final String createdDate,
             @RequestParam(required = false, defaultValue = "5") final int size
     ) {
         final SearchingTags searchingTags = new SearchingTags(generations, areas, tags);
-        final StudiesResponse studiesResponse = searchingStudyService.getStudies(title.trim(), searchingTags, id, createdAt, size);
+        final StudiesResponse studiesResponse = searchingStudyService.getStudies(title.trim(), searchingTags, id,
+                createdDate, size);
         return ResponseEntity.ok().body(studiesResponse);
     }
 

--- a/backend/src/main/java/com/woowacourse/moamoa/study/controller/SearchingStudyController.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/controller/SearchingStudyController.java
@@ -4,6 +4,7 @@ import com.woowacourse.moamoa.study.query.SearchingTags;
 import com.woowacourse.moamoa.study.service.SearchingStudyService;
 import com.woowacourse.moamoa.study.service.response.StudiesResponse;
 import com.woowacourse.moamoa.study.service.response.StudyDetailResponse;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -24,14 +25,18 @@ public class SearchingStudyController {
 
     @GetMapping
     public ResponseEntity<StudiesResponse> getStudies(
+            @RequestParam(required = false) final Long id,
+            @RequestParam(required = false) final LocalDateTime createdAt,
             @PageableDefault(size = 5) final Pageable pageable
     ) {
-        final StudiesResponse studiesResponse = searchingStudyService.getStudies("", SearchingTags.emptyTags(), pageable);
+        final StudiesResponse studiesResponse = searchingStudyService.getStudies("", SearchingTags.emptyTags(), id, createdAt, pageable);
         return ResponseEntity.ok().body(studiesResponse);
     }
 
     @GetMapping("/search")
     public ResponseEntity<StudiesResponse> searchStudies(
+            @RequestParam(required = false) final Long id,
+            @RequestParam(required = false) final LocalDateTime createdAt,
             @RequestParam(required = false, defaultValue = "") final String title,
             @RequestParam(required = false, name = "generation", defaultValue = "") final List<Long> generations,
             @RequestParam(required = false, name = "area", defaultValue = "") final List<Long> areas,
@@ -39,7 +44,7 @@ public class SearchingStudyController {
             @PageableDefault(size = 5) final Pageable pageable
     ) {
         final SearchingTags searchingTags = new SearchingTags(generations, areas, tags);
-        final StudiesResponse studiesResponse = searchingStudyService.getStudies(title.trim(), searchingTags, pageable);
+        final StudiesResponse studiesResponse = searchingStudyService.getStudies(title.trim(), searchingTags, id, createdAt, pageable);
         return ResponseEntity.ok().body(studiesResponse);
     }
 

--- a/backend/src/main/java/com/woowacourse/moamoa/study/controller/SearchingStudyController.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/controller/SearchingStudyController.java
@@ -7,8 +7,7 @@ import com.woowacourse.moamoa.study.service.response.StudyDetailResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,25 +25,25 @@ public class SearchingStudyController {
     @GetMapping
     public ResponseEntity<StudiesResponse> getStudies(
             @RequestParam(required = false) final Long id,
-            @RequestParam(required = false) final LocalDateTime createdAt,
-            @PageableDefault(size = 5) final Pageable pageable
+            @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") @RequestParam(required = false) final LocalDateTime createdAt,
+            @RequestParam(required = false, defaultValue = "5") final int size
     ) {
-        final StudiesResponse studiesResponse = searchingStudyService.getStudies("", SearchingTags.emptyTags(), id, createdAt, pageable);
+        final StudiesResponse studiesResponse = searchingStudyService.getStudies("", SearchingTags.emptyTags(), id, createdAt, size);
         return ResponseEntity.ok().body(studiesResponse);
     }
 
     @GetMapping("/search")
     public ResponseEntity<StudiesResponse> searchStudies(
-            @RequestParam(required = false) final Long id,
-            @RequestParam(required = false) final LocalDateTime createdAt,
             @RequestParam(required = false, defaultValue = "") final String title,
             @RequestParam(required = false, name = "generation", defaultValue = "") final List<Long> generations,
             @RequestParam(required = false, name = "area", defaultValue = "") final List<Long> areas,
             @RequestParam(required = false, name = "subject", defaultValue = "") final List<Long> tags,
-            @PageableDefault(size = 5) final Pageable pageable
+            @RequestParam(required = false) final Long id,
+            @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") @RequestParam(required = false) final LocalDateTime createdAt,
+            @RequestParam(required = false, defaultValue = "5") final int size
     ) {
         final SearchingTags searchingTags = new SearchingTags(generations, areas, tags);
-        final StudiesResponse studiesResponse = searchingStudyService.getStudies(title.trim(), searchingTags, id, createdAt, pageable);
+        final StudiesResponse studiesResponse = searchingStudyService.getStudies(title.trim(), searchingTags, id, createdAt, size);
         return ResponseEntity.ok().body(studiesResponse);
     }
 

--- a/backend/src/main/java/com/woowacourse/moamoa/study/query/SearchingTags.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/query/SearchingTags.java
@@ -32,4 +32,10 @@ public class SearchingTags {
     public static SearchingTags emptyTags() {
         return new SearchingTags(List.of(), List.of(), List.of());
     }
+
+    public boolean isEmpty() {
+        return tags.values()
+                .stream()
+                .allMatch(List::isEmpty);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/moamoa/study/query/StudySummaryDao.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/query/StudySummaryDao.java
@@ -2,6 +2,8 @@ package com.woowacourse.moamoa.study.query;
 
 import com.woowacourse.moamoa.study.query.data.StudySummaryData;
 import com.woowacourse.moamoa.tag.domain.CategoryName;
+import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,28 +33,23 @@ public class StudySummaryDao {
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
-    public Slice<StudySummaryData> searchBy(final String title, final SearchingTags searchingTags, final Pageable pageable) {
+    public Slice<StudySummaryData> searchBy(final String title, final SearchingTags searchingTags, final Long id,
+                                            final LocalDateTime createdAt, final Pageable pageable) {
         final List<StudySummaryData> data = jdbcTemplate
-                .query(sql(searchingTags, title), params(title, searchingTags, pageable), STUDY_ROW_MAPPER);
+                .query(sql(title, searchingTags, id, createdAt), params(title, searchingTags, id, createdAt, pageable),
+                        STUDY_ROW_MAPPER);
         return new SliceImpl<>(getCurrentPageStudies(data, pageable), pageable, hasNext(data, pageable));
     }
 
-    private String sql(final SearchingTags searchingTags, final String title) {
+    private String sql(final String title, final SearchingTags searchingTags, final Long id,
+                       final LocalDateTime createdAt) {
         return "SELECT study.id, study.title, study.excerpt, study.thumbnail, study.recruitment_status, study.created_at "
-                + "FROM study "
-                + joinTableClause(searchingTags)
-                + joinTitleClause(title)
-                + filtersInQueryClause(searchingTags)
-                + "GROUP BY study.id "
-                + "ORDER BY study.created_at DESC "
-                + "LIMIT :limit OFFSET :offset ";
-    }
-
-    private String joinTitleClause(final String title) {
-        if (title.isBlank()) {
-            return "";
-        }
-        return "WHERE UPPER(study.title) LIKE UPPER(:title) ESCAPE '\' ";
+                        + "FROM study "
+                        + joinTableClause(searchingTags)
+                        + whereCondition(id, createdAt, title, searchingTags)
+                        + "GROUP BY study.id "
+                        + "ORDER BY study.created_at DESC, id DESC "
+                        + "LIMIT :limit ";
     }
 
     private String joinTableClause(final SearchingTags searchingTags) {
@@ -66,6 +63,45 @@ public class StudySummaryDao {
                 .collect(Collectors.joining());
     }
 
+    private String whereCondition(final Long id, final LocalDateTime createdAt, final String title,
+                                  final SearchingTags searchingTags) {
+        if (!hasCondition(id, createdAt, title, searchingTags)) {
+            return "";
+        }
+
+        final String cursorClause = filtersInCursorClause(id, createdAt);
+        final String titleClause = filtersTitleClause(title);
+        final String filtersInQueryClause = filtersInQueryClause(searchingTags);
+        final String combinedClause = combineClause(cursorClause, titleClause);
+
+        if (combinedClause.isBlank()) {
+            return "WHERE " + filtersInQueryClause.replaceFirst("AND ", "");
+        }
+
+        return "WHERE " + combineClause(cursorClause, titleClause) + filtersInQueryClause;
+    }
+
+    private boolean hasCondition(final Long id, final LocalDateTime createdAt,
+                                        final String title, final SearchingTags searchingTags) {
+        return id != null || createdAt != null || !title.isBlank() || !searchingTags.isEmpty();
+    }
+
+
+    private String filtersInCursorClause(final Long id, final LocalDateTime createdAt) {
+        if (id != null && createdAt != null) {
+            return "(study.created_at < :createdAt OR (study.created_at = :createdAt AND id < :id)) ";
+        }
+
+        return "";
+    }
+
+    private String filtersTitleClause(final String title) {
+        if (title.isBlank()) {
+            return "";
+        }
+        return "UPPER(study.title) LIKE UPPER(:title) ESCAPE '\' ";
+    }
+
     private String filtersInQueryClause(final SearchingTags searchingTags) {
         String sql = "AND {}_tag.id IN (:{}) ";
 
@@ -75,20 +111,40 @@ public class StudySummaryDao {
                 .collect(Collectors.joining());
     }
 
-    private Map<String, Object> params(final String title, final SearchingTags searchingTags,
+    private String combineClause(String... clauses) {
+        final List<String> notBlankClauses = Arrays.stream(clauses)
+                .filter(it -> !it.isBlank())
+                .collect(Collectors.toList());
+
+        if (notBlankClauses.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder stringBuilder = new StringBuilder(notBlankClauses.get(0));
+        for (int i = 1; i < notBlankClauses.size(); i++) {
+            stringBuilder.append("AND " + notBlankClauses.get(i));
+        }
+
+        return stringBuilder.toString();
+    }
+
+    private Map<String, Object> params(final String title, final SearchingTags searchingTags, final Long id,
+                                       final LocalDateTime createdAt,
                                        final Pageable pageable) {
         final Map<String, Object> tagIds = Stream.of(CategoryName.values())
                 .collect(Collectors.toMap(name -> name.name().toLowerCase(), searchingTags::getTagIdsBy));
 
         Map<String, Object> param = new HashMap<>();
         param.put("title", "%" + title + "%");
+        param.put("id", id);
+        param.put("createdAt", createdAt);
         param.put("limit", pageable.getPageSize() + 1);
-        param.put("offset", pageable.getOffset());
         param.putAll(tagIds);
         return param;
     }
 
-    private List<StudySummaryData> getCurrentPageStudies(final List<StudySummaryData> studies, final Pageable pageable) {
+    private List<StudySummaryData> getCurrentPageStudies(final List<StudySummaryData> studies,
+                                                         final Pageable pageable) {
         if (hasNext(studies, pageable)) {
             return studies.subList(0, studies.size() - 1);
         }

--- a/backend/src/main/java/com/woowacourse/moamoa/study/query/StudySummaryDao.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/query/StudySummaryDao.java
@@ -27,8 +27,9 @@ public class StudySummaryDao {
         final String excerpt = resultSet.getString("excerpt");
         final String thumbnail = resultSet.getString("thumbnail");
         final String status = resultSet.getString("recruitment_status");
+        final LocalDateTime createdDate = resultSet.getObject("created_at", LocalDateTime.class);
 
-        return new StudySummaryData(id, title, excerpt, thumbnail, status);
+        return new StudySummaryData(id, title, excerpt, thumbnail, status, createdDate);
     };
 
     private final NamedParameterJdbcTemplate jdbcTemplate;

--- a/backend/src/main/java/com/woowacourse/moamoa/study/query/data/StudySummaryData.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/query/data/StudySummaryData.java
@@ -1,5 +1,6 @@
 package com.woowacourse.moamoa.study.query.data;
 
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,4 +15,5 @@ public class StudySummaryData {
     private String excerpt;
     private String thumbnail;
     private String recruitmentStatus;
+    private LocalDateTime createdDate;
 }

--- a/backend/src/main/java/com/woowacourse/moamoa/study/service/SearchingStudyService.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/service/SearchingStudyService.java
@@ -13,6 +13,7 @@ import com.woowacourse.moamoa.study.service.response.StudyDetailResponse;
 import com.woowacourse.moamoa.tag.query.TagDao;
 import com.woowacourse.moamoa.tag.query.response.TagData;
 import com.woowacourse.moamoa.tag.query.response.TagSummaryData;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -42,8 +43,9 @@ public class SearchingStudyService {
         this.tagDao = tagDao;
     }
 
-    public StudiesResponse getStudies(final String title, final SearchingTags searchingTags, final Pageable pageable) {
-        final Slice<StudySummaryData> studyData = studySummaryDao.searchBy(title.trim(), searchingTags, pageable);
+    public StudiesResponse getStudies(final String title, final SearchingTags searchingTags, final Long id, final
+                                      LocalDateTime createdAt, final Pageable pageable) {
+        final Slice<StudySummaryData> studyData = studySummaryDao.searchBy(title.trim(), searchingTags, id, createdAt, pageable);
 
         final List<Long> studyIds = studyData.getContent().stream()
                 .map(StudySummaryData::getId)

--- a/backend/src/main/java/com/woowacourse/moamoa/study/service/SearchingStudyService.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/service/SearchingStudyService.java
@@ -17,7 +17,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,9 +42,10 @@ public class SearchingStudyService {
         this.tagDao = tagDao;
     }
 
-    public StudiesResponse getStudies(final String title, final SearchingTags searchingTags, final Long id, final
-                                      LocalDateTime createdAt, final Pageable pageable) {
-        final Slice<StudySummaryData> studyData = studySummaryDao.searchBy(title.trim(), searchingTags, id, createdAt, pageable);
+    public StudiesResponse getStudies(final String title, final SearchingTags searchingTags, final Long id,
+                                      final LocalDateTime createdAt, final int size) {
+        final Slice<StudySummaryData> studyData = studySummaryDao.searchBy(title.trim(), searchingTags, id, createdAt,
+                size);
 
         final List<Long> studyIds = studyData.getContent().stream()
                 .map(StudySummaryData::getId)

--- a/backend/src/main/java/com/woowacourse/moamoa/study/service/response/StudiesResponse.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/service/response/StudiesResponse.java
@@ -1,38 +1,53 @@
 package com.woowacourse.moamoa.study.service.response;
 
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
+
 import com.woowacourse.moamoa.study.query.data.StudySummaryData;
 import com.woowacourse.moamoa.tag.query.response.TagSummaryData;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class StudiesResponse {
 
     private List<StudyResponse> studies;
     private boolean hasNext;
+    private Long id;
+    private String createdDate;
 
-    public StudiesResponse(
-            final List<StudySummaryData> studySummaryData,
-            final Map<Long, List<TagSummaryData>> studyTags,
-            final boolean hasNext
-    ) {
-
-        this.studies = getStudyResponses(studySummaryData, studyTags);
+    private StudiesResponse(final List<StudyResponse> studies, final boolean hasNext, final Long id,
+                           final String createdDate) {
+        this.studies = studies;
         this.hasNext = hasNext;
+        this.id = id;
+        this.createdDate = createdDate;
     }
 
-    private List<StudyResponse> getStudyResponses(
+    public static StudiesResponse of(final List<StudySummaryData> studySummaryData,
+                                     final Map<Long, List<TagSummaryData>> studyTags, final boolean hasNext) {
+        final List<StudyResponse> studies = getStudyResponses(studySummaryData, studyTags);
+        if (studies.isEmpty()) {
+            return new StudiesResponse(studies, hasNext, null, "");
+        }
+
+        final StudySummaryData lastStudy = getLastStudyResponse(studySummaryData);
+        return new StudiesResponse(studies, hasNext, lastStudy.getId(), lastStudy.getCreatedDate().format(ISO_DATE_TIME));
+    }
+
+    private static List<StudyResponse> getStudyResponses(
             final List<StudySummaryData> studiesSummaryData,
             final Map<Long, List<TagSummaryData>> studyTags
     ) {
         return studiesSummaryData.stream()
                 .map(studySummaryData -> new StudyResponse(studySummaryData, studyTags.get(studySummaryData.getId())))
                 .collect(Collectors.toList());
+    }
+
+    private static StudySummaryData getLastStudyResponse(final List<StudySummaryData> studies) {
+        return studies.get(studies.size() - 1);
     }
 }

--- a/backend/src/test/java/com/woowacourse/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/acceptance/AcceptanceTest.java
@@ -14,7 +14,6 @@ import com.woowacourse.acceptance.steps.Steps;
 import com.woowacourse.moamoa.MoamoaApplication;
 import com.woowacourse.moamoa.auth.service.oauthclient.response.GithubProfileResponse;
 import com.woowacourse.moamoa.auth.service.request.AccessTokenRequest;
-
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
@@ -34,7 +33,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.web.client.RestTemplate;
 
 @SpringBootTest(
         webEnvironment = WebEnvironment.RANDOM_PORT,
@@ -47,16 +45,13 @@ public class AcceptanceTest {
     protected RequestSpecification spec;
 
     @RegisterExtension
-    final RestDocumentationExtension restDocumentation = new RestDocumentationExtension (OUTPUT_DIRECTORY);
+    final RestDocumentationExtension restDocumentation = new RestDocumentationExtension(OUTPUT_DIRECTORY);
 
     @LocalServerPort
     protected int port;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
-
-    @Autowired
-    private RestTemplate restTemplate;
 
     @Autowired
     public SlackAlarmMockServer slackAlarmMockServer;

--- a/backend/src/test/java/com/woowacourse/acceptance/test/study/SearchingStudiesAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/acceptance/test/study/SearchingStudiesAcceptanceTest.java
@@ -18,6 +18,8 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 import com.woowacourse.acceptance.AcceptanceTest;
 import io.restassured.RestAssured;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,65 +34,41 @@ class SearchingStudiesAcceptanceTest extends AcceptanceTest {
     void setUp() {
         LocalDate 지금 = LocalDate.now();
 
-         짱구가().로그인하고().자바_스터디를()
+        짱구가().로그인하고().자바_스터디를()
                 .시작일자는(지금).태그는(자바_태그_ID, 우테코4기_태그_ID, BE_태그_ID)
                 .생성한다();
 
-         짱구가().로그인하고().리액트_스터디를()
+        짱구가().로그인하고().리액트_스터디를()
                 .시작일자는(지금).태그는(우테코4기_태그_ID, FE_태그_ID, 리액트_태그_ID)
                 .생성한다();
 
-         짱구가().로그인하고().자바스크립트_스터디를()
+        짱구가().로그인하고().자바스크립트_스터디를()
                 .시작일자는(지금).태그는(우테코4기_태그_ID, FE_태그_ID)
                 .생성한다();
 
-         짱구가().로그인하고().HTTP_스터디를()
+        짱구가().로그인하고().HTTP_스터디를()
                 .시작일자는(지금).태그는(우테코4기_태그_ID, BE_태그_ID)
                 .생성한다();
 
-         짱구가().로그인하고().알고리즘_스터디를()
+        짱구가().로그인하고().알고리즘_스터디를()
                 .시작일자는(지금)
                 .생성한다();
 
-         짱구가().로그인하고().리눅스_스터디를()
+        짱구가().로그인하고().리눅스_스터디를()
                 .시작일자는(지금)
                 .생성한다();
     }
 
     @DisplayName("잘못된 페이징 정보로 목록을 검색시 400에러를 응답한다.")
     @ParameterizedTest
-    @CsvSource({"-1,3", "1,0", "one,1", "1,one"})
-    void response400WhenRequestByInvalidPagingInfo(String page, String size) {
+    @CsvSource({"one, 1", "1, one"})
+    void response400WhenRequestByInvalidPagingInfo(String id, String size) {
         RestAssured.given().log().all()
                 .queryParam("title", "java")
-                .queryParam("page", page)
+                .queryParam("id", id)
+                .queryParam("createdAt",
+                        LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
                 .queryParam("size", size)
-                .when().log().all()
-                .get("/api/studies/search")
-                .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value())
-                .body("message", not(blankOrNullString()));
-    }
-
-    @DisplayName("페이지 정보 없이 목록 검색시 400에러를 응답한다.")
-    @Test
-    void getStudiesByDefaultPage() {
-        RestAssured.given().log().all()
-                .queryParam("title", "java")
-                .queryParam("size", 5)
-                .when().log().all()
-                .get("/api/studies/search")
-                .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value())
-                .body("message", not(blankOrNullString()));
-    }
-
-    @DisplayName("사이즈 정보 없이 목록 조회시 400에러를 응답한다.")
-    @Test
-    void getStudiesByDefaultSize() {
-        RestAssured.given().log().all()
-                .queryParam("title", "java")
-                .queryParam("page", 0)
                 .when().log().all()
                 .get("/api/studies/search")
                 .then().log().all()
@@ -117,7 +95,9 @@ class SearchingStudiesAcceptanceTest extends AcceptanceTest {
                 .body("studies.thumbnail", contains(
                         "linux thumbnail", "algorithm thumbnail", "http thumbnail", "javascript thumbnail",
                         "react thumbnail"))
-                .body("studies.recruitmentStatus", contains("RECRUITMENT_START", "RECRUITMENT_START", "RECRUITMENT_START", "RECRUITMENT_START", "RECRUITMENT_START"));
+                .body("studies.recruitmentStatus",
+                        contains("RECRUITMENT_START", "RECRUITMENT_START", "RECRUITMENT_START", "RECRUITMENT_START",
+                                "RECRUITMENT_START"));
     }
 
     @DisplayName("앞뒤 공백을 제거한 키워드로 스터디 목록을 조회한다.")
@@ -223,7 +203,8 @@ class SearchingStudiesAcceptanceTest extends AcceptanceTest {
                 .body("studies.excerpt", contains("HTTP 설명", "자바스크립트 설명", "리액트 설명", "자바 설명"))
                 .body("studies.thumbnail",
                         contains("http thumbnail", "javascript thumbnail", "react thumbnail", "java thumbnail"))
-                .body("studies.recruitmentStatus", contains("RECRUITMENT_START", "RECRUITMENT_START", "RECRUITMENT_START", "RECRUITMENT_START"));
+                .body("studies.recruitmentStatus",
+                        contains("RECRUITMENT_START", "RECRUITMENT_START", "RECRUITMENT_START", "RECRUITMENT_START"));
     }
 
     @DisplayName("서로 다른 카테고리의 필터로 필터링하여 스터디 목록을 조회한다.")

--- a/backend/src/test/java/com/woowacourse/moamoa/study/controller/SearchingStudyControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/study/controller/SearchingStudyControllerTest.java
@@ -31,7 +31,6 @@ import com.woowacourse.moamoa.study.service.response.StudyDetailResponse;
 import com.woowacourse.moamoa.tag.query.TagDao;
 import com.woowacourse.moamoa.tag.query.response.TagData;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import javax.persistence.EntityManager;
 import org.assertj.core.groups.Tuple;
@@ -49,7 +48,7 @@ import org.springframework.web.client.RestTemplate;
 class SearchingStudyControllerTest {
 
     private static final Long EMPTY_CURSOR_ID = null;
-    private static final LocalDateTime EMPTY_CURSOR_CREATED_AT = null;
+    private static final String EMPTY_CURSOR_CREATED_AT = "";
 
     private SearchingStudyController sut;
 

--- a/backend/src/test/java/com/woowacourse/moamoa/study/controller/SearchingStudyControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/study/controller/SearchingStudyControllerTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
@@ -89,6 +88,7 @@ class SearchingStudyControllerTest {
 
     @BeforeEach
     void initDataBase() {
+
         jjanggu = memberRepository.save(MemberFixtures.짱구());
         greenlawn = memberRepository.save(MemberFixtures.그린론());
         dwoo = memberRepository.save(MemberFixtures.디우());
@@ -144,8 +144,7 @@ class SearchingStudyControllerTest {
     @DisplayName("페이징 정보로 스터디 목록 조회")
     @Test
     void getStudies() {
-        ResponseEntity<StudiesResponse> response = sut.getStudies(EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT,
-                PageRequest.of(0, 3));
+        ResponseEntity<StudiesResponse> response = sut.getStudies(EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, 3);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
@@ -164,9 +163,7 @@ class SearchingStudyControllerTest {
     @Test
     void searchByBlankKeyword() {
         ResponseEntity<StudiesResponse> response = sut
-                .searchStudies(EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, "", emptyList(), emptyList(), emptyList(),
-                        PageRequest.of(0, 3)
-                );
+                .searchStudies("", emptyList(), emptyList(), emptyList(), EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, 3);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
@@ -185,10 +182,7 @@ class SearchingStudyControllerTest {
     @Test
     void searchByKeyword() {
         ResponseEntity<StudiesResponse> response = sut
-                .searchStudies(EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, "Java 스터디", emptyList(), emptyList(),
-                        emptyList(),
-                        PageRequest.of(0, 3)
-                );
+                .searchStudies("Java 스터디", emptyList(), emptyList(), emptyList(), EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, 3);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
@@ -203,8 +197,7 @@ class SearchingStudyControllerTest {
     @Test
     void searchWithTrimKeyword() {
         ResponseEntity<StudiesResponse> response = sut
-                .searchStudies(EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, "   Java 스터디   ", emptyList(), emptyList(),
-                        emptyList(), PageRequest.of(0, 3));
+                .searchStudies("   Java 스터디   ", emptyList(), emptyList(), emptyList(), EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, 3);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
@@ -222,8 +215,7 @@ class SearchingStudyControllerTest {
         List<Long> areas = List.of(3L); // BE
 
         ResponseEntity<StudiesResponse> response = sut
-                .searchStudies(EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, "", emptyList(), areas, tags,
-                        PageRequest.of(0, 3));
+                .searchStudies("", emptyList(), areas, tags, EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, 3);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
@@ -238,8 +230,7 @@ class SearchingStudyControllerTest {
         List<Long> areaIds = List.of(3L, 4L); // BE, FE
         List<Long> tagIds = List.of(1L, 5L); // Java, React
         ResponseEntity<StudiesResponse> response = sut
-                .searchStudies(EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, "", generationIds, areaIds, tagIds,
-                        PageRequest.of(0, 3));
+                .searchStudies("", generationIds, areaIds, tagIds, EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, 3);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();

--- a/backend/src/test/java/com/woowacourse/moamoa/study/query/StudySummaryDaoTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/study/query/StudySummaryDaoTest.java
@@ -34,8 +34,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.web.client.RestTemplate;
 
@@ -151,10 +149,10 @@ class StudySummaryDaoTest {
     @DisplayName("페이징 정보를 사용해 스터디 목록 조회")
     @ParameterizedTest
     @MethodSource("providePageableAndExpect")
-    void findAllByPageable(Pageable pageable, Long cursorId, LocalDateTime createdAt, List<Tuple> expectedTuples,
+    void findAllByPageable(int size, Long cursorId, LocalDateTime createdAt, List<Tuple> expectedTuples,
                            boolean expectedHasNext) {
         final Slice<StudySummaryData> response = studySummaryDao.searchBy("", SearchingTags.emptyTags(), cursorId,
-                createdAt, pageable);
+                createdAt, size);
 
         assertThat(response.hasNext()).isEqualTo(expectedHasNext);
         assertThat(response.getContent())
@@ -175,13 +173,13 @@ class StudySummaryDaoTest {
         );
 
         return Stream.of(
-                Arguments.of(PageRequest.of(0, 3),
+                Arguments.of(3,
                         EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT,
                         tuples.subList(0, 3), true),
-                Arguments.of(PageRequest.of(1, 2),
+                Arguments.of(2,
                         알고리즘_ID, LocalDateTime.of(2023, 11, 7, 1, 0, 0),
                         tuples.subList(2, 4), true),
-                Arguments.of(PageRequest.of(1, 3),
+                Arguments.of(3,
                         HTTP_ID, LocalDateTime.of(2023, 11, 7, 0, 0, 0),
                         tuples.subList(3, 6), false)
         );
@@ -191,8 +189,7 @@ class StudySummaryDaoTest {
     @Test
     void findByTitleContaining() {
         final Slice<StudySummaryData> response = studySummaryDao
-                .searchBy("java", SearchingTags.emptyTags(), EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT,
-                        PageRequest.of(0, 3));
+                .searchBy("java", SearchingTags.emptyTags(), EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, 3);
 
         assertThat(response.hasNext()).isFalse();
         assertThat(response.getContent())
@@ -209,7 +206,7 @@ class StudySummaryDaoTest {
     @Test
     void findByBlankTitle() {
         final Slice<StudySummaryData> response = studySummaryDao.searchBy(
-                "", SearchingTags.emptyTags(), EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, PageRequest.of(0, 5));
+                "", SearchingTags.emptyTags(), EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, 5);
 
         assertThat(response.hasNext()).isTrue();
         assertThat(response.getContent())
@@ -230,7 +227,7 @@ class StudySummaryDaoTest {
     @MethodSource("provideOneKindFiltersAndExpectResult")
     void searchByOneKindFilter(SearchingTags searchingTags, List<Tuple> tuples) {
         Slice<StudySummaryData> response = studySummaryDao.searchBy(
-                "", searchingTags, EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, PageRequest.of(0, 3));
+                "", searchingTags, EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, 3);
 
         assertThat(response.hasNext()).isFalse();
         assertThat(response.getContent())
@@ -262,7 +259,7 @@ class StudySummaryDaoTest {
     @MethodSource("provideFiltersAndExpectResult")
     void searchByUnableToFoundTags(SearchingTags searchingTags, List<Tuple> tuples, boolean hasNext) {
         Slice<StudySummaryData> response = studySummaryDao.searchBy(
-                "", searchingTags, EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, PageRequest.of(0, 3));
+                "", searchingTags, EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, 3);
 
         assertThat(response.hasNext()).isEqualTo(hasNext);
         assertThat(response.getContent())

--- a/backend/src/test/java/com/woowacourse/moamoa/study/query/StudySummaryDaoTest.java
+++ b/backend/src/test/java/com/woowacourse/moamoa/study/query/StudySummaryDaoTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.moamoa.study.query;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 import com.woowacourse.moamoa.alarm.SlackAlarmSender;
 import com.woowacourse.moamoa.alarm.SlackUsersClient;
@@ -27,6 +28,7 @@ import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -37,9 +39,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.web.client.RestTemplate;
 
+@TestInstance(PER_CLASS)
 @RepositoryTest
 @Import({RestTemplate.class, SlackAlarmSender.class, SlackUsersClient.class})
 class StudySummaryDaoTest {
+
+    private static final Long EMPTY_CURSOR_ID = null;
+    private static final LocalDateTime EMPTY_CURSOR_CREATED_AT = null;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -58,6 +64,13 @@ class StudySummaryDaoTest {
     private Member dwoo;
     private Member verus;
 
+    private Long 리눅스_ID;
+    private Long 알고리즘_ID;
+    private Long HTTP_ID;
+    private Long 자바스크립트_ID;
+    private Long 리액트_ID;
+    private Long 자바_ID;
+
     @BeforeEach
     void initDataBase() {
         jjanggu = memberRepository.save(MemberFixtures.짱구());
@@ -65,62 +78,7 @@ class StudySummaryDaoTest {
         dwoo = memberRepository.save(MemberFixtures.디우());
         verus = memberRepository.save(MemberFixtures.베루스());
 
-        studyRepository.save(
-                new Study(
-                        new Content("Java 스터디", "자바 설명", "java thumbnail", "그린론의 우당탕탕 자바 스터디입니다."),
-                        new Participants(greenlawn.getId(), Set.of(dwoo.getId(), verus.getId())),
-                        new AttachedTags(List.of(new AttachedTag(1L), new AttachedTag(2L), new AttachedTag(3L))),
-                        LocalDateTime.of(2022, 12, 8, 0, 0, 0),
-                        10, LocalDate.of(2022, 12, 9),
-                        LocalDate.of(2022, 12, 9), LocalDate.of(2022, 12, 11)
-                        )
-        );
-
-        studyRepository.save(
-                new Study(
-                        new Content("React 스터디", "리액트 설명", "react thumbnail", "디우의 뤼액트 스터디입니다."),
-                        new Participants(dwoo.getId(), Set.of(jjanggu.getId(), greenlawn.getId(), verus.getId())),
-                        new AttachedTags(List.of(new AttachedTag(2L), new AttachedTag(4L), new AttachedTag(5L))),
-                        LocalDateTime.of(2022, 12, 8, 1, 0, 0),
-                        5, LocalDate.of(2022, 12, 9),
-                        LocalDate.of(2022, 12, 9), LocalDate.of(2022, 12, 10)
-                )
-        );
-
-        studyRepository.save(
-                new Study(
-                        new Content("javaScript 스터디", "자바스크립트 설명", "javascript thumbnail", "그린론의 자바스크립트 접해보기"),
-                        new Participants(dwoo.getId(), Set.of(verus.getId())),
-                        new AttachedTags(List.of(new AttachedTag(2L), new AttachedTag(4L))),
-                        LocalDateTime.of(2022, 12, 8, 2, 0, 0),
-                        20, LocalDate.of(2022, 12, 9),
-                        LocalDate.of(2022, 12, 9), LocalDate.of(2022, 12, 11)
-                )
-        );
-
-        studyRepository.save(
-                new Study(
-                        new Content("HTTP 스터디", "HTTP 설명", "http thumbnail", "디우의 HTTP 정복하기"),
-                        new Participants(jjanggu.getId(), Set.of(dwoo.getId(), verus.getId())),
-                        new AttachedTags(List.of(new AttachedTag(2L), new AttachedTag(3L))),
-                        LocalDateTime.of(2023, 11, 7, 0, 0, 0),
-                        3, LocalDate.of(2023, 11, 8),
-                        LocalDate.of(2023, 12, 9), LocalDate.of(2023, 12, 11)
-                )
-        );
-
-        studyRepository.save(
-                new Study(
-                        new Content("알고리즘 스터디", "알고리즘 설명", "algorithm thumbnail", "알고리즘을 TDD로 풀자의 베루스입니다."),
-                        new Participants(dwoo.getId(), Set.of(verus.getId())),
-                        new AttachedTags(List.of()),
-                        LocalDateTime.of(2023, 11, 7, 1, 0, 0),
-                        2, LocalDate.of(2023, 11, 8),
-                        LocalDate.of(2023, 12, 9), LocalDate.of(2023, 12, 11)
-                )
-        );
-
-        studyRepository.save(
+        리눅스_ID = studyRepository.save(
                 new Study(
                         new Content("Linux 스터디", "리눅스 설명", "linux thumbnail", "Linux를 공부하자의 베루스입니다."),
                         new Participants(dwoo.getId(), Set.of(verus.getId())),
@@ -129,7 +87,62 @@ class StudySummaryDaoTest {
                         2, LocalDate.of(2023, 11, 8),
                         LocalDate.of(2023, 12, 9), LocalDate.of(2023, 12, 11)
                 )
-        );
+        ).getId();
+
+        알고리즘_ID = studyRepository.save(
+                new Study(
+                        new Content("알고리즘 스터디", "알고리즘 설명", "algorithm thumbnail", "알고리즘을 TDD로 풀자의 베루스입니다."),
+                        new Participants(dwoo.getId(), Set.of(verus.getId())),
+                        new AttachedTags(List.of()),
+                        LocalDateTime.of(2023, 11, 7, 1, 0, 0),
+                        2, LocalDate.of(2023, 11, 8),
+                        LocalDate.of(2023, 12, 9), LocalDate.of(2023, 12, 11)
+                )
+        ).getId();
+
+        HTTP_ID = studyRepository.save(
+                new Study(
+                        new Content("HTTP 스터디", "HTTP 설명", "http thumbnail", "디우의 HTTP 정복하기"),
+                        new Participants(jjanggu.getId(), Set.of(dwoo.getId(), verus.getId())),
+                        new AttachedTags(List.of(new AttachedTag(2L), new AttachedTag(3L))),
+                        LocalDateTime.of(2023, 11, 7, 0, 0, 0),
+                        3, LocalDate.of(2023, 11, 8),
+                        LocalDate.of(2023, 12, 9), LocalDate.of(2023, 12, 11)
+                )
+        ).getId();
+
+        자바스크립트_ID = studyRepository.save(
+                new Study(
+                        new Content("javaScript 스터디", "자바스크립트 설명", "javascript thumbnail", "그린론의 자바스크립트 접해보기"),
+                        new Participants(dwoo.getId(), Set.of(verus.getId())),
+                        new AttachedTags(List.of(new AttachedTag(2L), new AttachedTag(4L))),
+                        LocalDateTime.of(2022, 12, 8, 2, 0, 0),
+                        20, LocalDate.of(2022, 12, 9),
+                        LocalDate.of(2022, 12, 9), LocalDate.of(2022, 12, 11)
+                )
+        ).getId();
+
+        리액트_ID = studyRepository.save(
+                new Study(
+                        new Content("React 스터디", "리액트 설명", "react thumbnail", "디우의 뤼액트 스터디입니다."),
+                        new Participants(dwoo.getId(), Set.of(jjanggu.getId(), greenlawn.getId(), verus.getId())),
+                        new AttachedTags(List.of(new AttachedTag(2L), new AttachedTag(4L), new AttachedTag(5L))),
+                        LocalDateTime.of(2022, 12, 8, 1, 0, 0),
+                        5, LocalDate.of(2022, 12, 9),
+                        LocalDate.of(2022, 12, 9), LocalDate.of(2022, 12, 10)
+                )
+        ).getId();
+
+        자바_ID = studyRepository.save(
+                new Study(
+                        new Content("Java 스터디", "자바 설명", "java thumbnail", "그린론의 우당탕탕 자바 스터디입니다."),
+                        new Participants(greenlawn.getId(), Set.of(dwoo.getId(), verus.getId())),
+                        new AttachedTags(List.of(new AttachedTag(1L), new AttachedTag(2L), new AttachedTag(3L))),
+                        LocalDateTime.of(2022, 12, 8, 0, 0, 0),
+                        10, LocalDate.of(2022, 12, 9),
+                        LocalDate.of(2022, 12, 9), LocalDate.of(2022, 12, 11)
+                )
+        ).getId();
 
         em.flush();
         em.clear();
@@ -138,8 +151,10 @@ class StudySummaryDaoTest {
     @DisplayName("페이징 정보를 사용해 스터디 목록 조회")
     @ParameterizedTest
     @MethodSource("providePageableAndExpect")
-    void findAllByPageable(Pageable pageable, List<Tuple> expectedTuples, boolean expectedHasNext) {
-        final Slice<StudySummaryData> response = studySummaryDao.searchBy("", SearchingTags.emptyTags(), pageable);
+    void findAllByPageable(Pageable pageable, Long cursorId, LocalDateTime createdAt, List<Tuple> expectedTuples,
+                           boolean expectedHasNext) {
+        final Slice<StudySummaryData> response = studySummaryDao.searchBy("", SearchingTags.emptyTags(), cursorId,
+                createdAt, pageable);
 
         assertThat(response.hasNext()).isEqualTo(expectedHasNext);
         assertThat(response.getContent())
@@ -149,7 +164,7 @@ class StudySummaryDaoTest {
                 .containsExactlyElementsOf(expectedTuples);
     }
 
-    private static Stream<Arguments> providePageableAndExpect() {
+    private Stream<Arguments> providePageableAndExpect() {
         List<Tuple> tuples = List.of(
                 tuple("Linux 스터디", "리눅스 설명", "linux thumbnail", "RECRUITMENT_END"),
                 tuple("알고리즘 스터디", "알고리즘 설명", "algorithm thumbnail", "RECRUITMENT_END"),
@@ -160,9 +175,15 @@ class StudySummaryDaoTest {
         );
 
         return Stream.of(
-                Arguments.of(PageRequest.of(0, 3), tuples.subList(0, 3), true),
-                Arguments.of(PageRequest.of(1, 2), tuples.subList(2, 4), true),
-                Arguments.of(PageRequest.of(1, 3), tuples.subList(3, 6), false)
+                Arguments.of(PageRequest.of(0, 3),
+                        EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT,
+                        tuples.subList(0, 3), true),
+                Arguments.of(PageRequest.of(1, 2),
+                        알고리즘_ID, LocalDateTime.of(2023, 11, 7, 1, 0, 0),
+                        tuples.subList(2, 4), true),
+                Arguments.of(PageRequest.of(1, 3),
+                        HTTP_ID, LocalDateTime.of(2023, 11, 7, 0, 0, 0),
+                        tuples.subList(3, 6), false)
         );
     }
 
@@ -170,7 +191,8 @@ class StudySummaryDaoTest {
     @Test
     void findByTitleContaining() {
         final Slice<StudySummaryData> response = studySummaryDao
-                .searchBy("java", SearchingTags.emptyTags(), PageRequest.of(0, 3));
+                .searchBy("java", SearchingTags.emptyTags(), EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT,
+                        PageRequest.of(0, 3));
 
         assertThat(response.hasNext()).isFalse();
         assertThat(response.getContent())
@@ -186,8 +208,8 @@ class StudySummaryDaoTest {
     @DisplayName("빈 키워드와 함께 페이징 정보를 사용해 스터디 목록 조회")
     @Test
     void findByBlankTitle() {
-        final Slice<StudySummaryData> response = studySummaryDao.searchBy("", SearchingTags.emptyTags(),
-                PageRequest.of(0, 5));
+        final Slice<StudySummaryData> response = studySummaryDao.searchBy(
+                "", SearchingTags.emptyTags(), EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, PageRequest.of(0, 5));
 
         assertThat(response.hasNext()).isTrue();
         assertThat(response.getContent())
@@ -207,7 +229,8 @@ class StudySummaryDaoTest {
     @ParameterizedTest
     @MethodSource("provideOneKindFiltersAndExpectResult")
     void searchByOneKindFilter(SearchingTags searchingTags, List<Tuple> tuples) {
-        Slice<StudySummaryData> response = studySummaryDao.searchBy("", searchingTags, PageRequest.of(0, 3));
+        Slice<StudySummaryData> response = studySummaryDao.searchBy(
+                "", searchingTags, EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, PageRequest.of(0, 3));
 
         assertThat(response.hasNext()).isFalse();
         assertThat(response.getContent())
@@ -238,7 +261,8 @@ class StudySummaryDaoTest {
     @ParameterizedTest
     @MethodSource("provideFiltersAndExpectResult")
     void searchByUnableToFoundTags(SearchingTags searchingTags, List<Tuple> tuples, boolean hasNext) {
-        Slice<StudySummaryData> response = studySummaryDao.searchBy("", searchingTags, PageRequest.of(0, 3));
+        Slice<StudySummaryData> response = studySummaryDao.searchBy(
+                "", searchingTags, EMPTY_CURSOR_ID, EMPTY_CURSOR_CREATED_AT, PageRequest.of(0, 3));
 
         assertThat(response.hasNext()).isEqualTo(hasNext);
         assertThat(response.getContent())


### PR DESCRIPTION
## 요약

스터디 목록 조회에 대해서 커서 기반의 페이징으로 변경한다.

## 세부사항

현재 offset 기반의 페이징의 경우 예를 들어 50,000 ~ 50,005 번째의 5개의 데이터를 조회해오기 위해서는 DB 디스크에서 50,005 개의 데이터를 모두 읽어와야하며 디스크를 읽을 때 랜덤I/O 가 발생해 성능상 문제가 많습니다.
이를 해결하기 위한 방법인 커서 기반의 페이징을 적용하여 50,000 ~ 50,005 번째의 5개의 데이터를 조회해오더라도 필요한 데이터인 5개만 디스크로 부터 읽어올 수 있도록 개선합니다.
우선은 가장 빈번한 조회가 일어나는 메인 페이지의 study 목록 조회에 대해서 적용합니다.

참고 : [커서 기반 페이지네이션 (Cursor-based Pagination) 구현하기](https://velog.io/@minsangk/%EC%BB%A4%EC%84%9C-%EA%B8%B0%EB%B0%98-%ED%8E%98%EC%9D%B4%EC%A7%80%EB%84%A4%EC%9D%B4%EC%85%98-Cursor-based-Pagination-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0)
참고 : [Faster Pagination in Mysql – Why Order By With Limit and Offset is Slow?](https://www.eversql.com/faster-pagination-in-mysql-why-order-by-with-limit-and-offset-is-slow/)

close #467
