### PR TITLE
hotfix: connection-time 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/moamoa/study/domain/repository/StudyRepository.java
+++ b/backend/src/main/java/com/woowacourse/moamoa/study/domain/repository/StudyRepository.java
@@ -17,7 +17,7 @@ public interface StudyRepository {
     Optional<Study> findById(Long id);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "1000")})
+    @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "3000")})
     @Query("select s from Study s where s.id = :id")
     Optional<Study> findByIdUpdateFor(@Param("id") Long id);
 


### PR DESCRIPTION
## 요약

커넥션 타임아웃에 대한 설정을 수정해주었습니다.

## 세부사항

이전에 HikariCP 설정 중 1초인 경우에 저희가 원하는 vUser 50명에서 Faile 이 발생하던 것을 근거로 1초 에서 3초로 수정을 진행하였습니다.
